### PR TITLE
Add noop jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,0 +1,9 @@
+---
+- project:
+    name: github.com/ansible/project-config
+    check:
+      jobs:
+        - noop
+    gate:
+      jobs:
+        - noop


### PR DESCRIPTION
While we have no testing, we can start gating ansible/project-config. No
longer manually merging of code.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>