### PR TITLE
Try to override upload-logs-swift logs url

### DIFF
--- a/playbooks/base-minimal-test/post-logs.yaml
+++ b/playbooks/base-minimal-test/post-logs.yaml
@@ -14,3 +14,13 @@
         name: upload-logs-swift
       vars:
         zuul_log_cloud_config: "{{ vexxhost_clouds_yaml }}"
+
+    - name: Setup log path fact
+      include_role:
+        name: set-zuul-log-path-fact
+
+    - name: Return log URL to Zuul
+      zuul_return:
+        data:
+          zuul:
+            log_url: "https://logs.zuul.ansible.com/{{ zuul_log_path }}/"


### PR DESCRIPTION
We don't want to return the URL from swift, we want to inject our own.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>