### PR TITLE
base-minimail-test: switch to centos-7-1vcpu nodeset

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -65,7 +65,4 @@
       ara_compress_html: false
     secrets:
       - vexxhost_clouds_yaml
-    nodeset:
-      nodes:
-        - name: ubuntu-bionic
-          label: ubuntu-bionic-1vcpu
+    nodeset: centos-7-1vcpu


### PR DESCRIPTION
Remove ubuntu-bionic, in favor of centos-7.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>