### PR TITLE
Remove project stanza for ansible-network/windmill-config

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,10 +7,3 @@
     gate:
       jobs:
         - tox-linters
-
-# NOTE(pabelanger): We current don't gate these projects.
-- project:
-    name: github.com/ansible-network/windmill-config
-    check:
-      jobs:
-        - noop


### PR DESCRIPTION
These jobs are now defined in tree.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>