### PR TITLE
Add noop jobs for ansible-network/packet-ci-cloud

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -6,6 +6,11 @@
       - ansible-python-jobs
 
 - project:
+    name: github.com/ansible-network/packet-ci-cloud
+    templates:
+      - noop-jobs
+
+- project:
     name: github.com/ansible-network/resource_module_builder
     templates:
       - noop-jobs


### PR DESCRIPTION
Start gating packet-ci-cloud with zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>