### PR TITLE
Add zuul tenants configuration

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -35,3 +35,6 @@
     gate:
       jobs:
         - tox-linters
+    promote:
+      jobs:
+        - windmill-config-deploy


### PR DESCRIPTION
We are moving this out from ansible-network/windmill-config to here to
make it easier for users to add zuul configuration in a single repo.

Also run windmill-config-deploy promote jobs, so we can deploy changes
for zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>