### PR TITLE
Add jobs for ansible-network/juniper_junos

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -13,6 +13,22 @@
       - ansible-python-jobs
 
 - project:
+    name: github.com/ansible-network/juniper_junos
+    default-branch: devel
+    templates:
+      - ansible-python-jobs
+    check:
+      jobs:
+        - ansible-tox-py27
+        - ansible-tox-py36
+        - ansible-tox-py37
+    gate:
+      jobs:
+        - ansible-tox-py27
+        - ansible-tox-py36
+        - ansible-tox-py37
+
+- project:
     name: github.com/ansible-network/packet-ci-cloud
     templates:
       - noop-jobs


### PR DESCRIPTION
Now that ansible-network/juniper_junos is added to our zuul tenant, we
can start running gate jobs again on it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>