### PR TITLE
Add noop-jobs to ansible-network/aws project

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -13,6 +13,12 @@
       - ansible-python-jobs
 
 - project:
+    name: github.com/ansible-network/aws
+    default-branch: devel
+    templates:
+      - noop-jobs
+
+- project:
     name: github.com/ansible-network/cisco_iosxr
     default-branch: devel
     templates:


### PR DESCRIPTION
This allows us to gate the project.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>