### PR TITLE
Add ansible/ansible-runner to ansible zuul tenant

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -30,6 +30,12 @@
           - ansible-network/sandbox
           - ansible-network/windmill-config
 
+          # Don't load any configuration from these projects because we
+          # don't gate them, so they could wedge our config.
+          - include: []
+            projects:
+              - ansible/ansible-runner
+
       git.openstack.org:
         untrusted-projects:
           - openstack-infra/zuul-jobs


### PR DESCRIPTION
We want to add ansible/ansible-runner to zuul.ansible.com, but not load
any jobs from it for now. This will allow us to do cross-project testing
to help the migration from sf.io.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>