### PR TITLE
Add ansible-network/network_configurator to ansible zuul tenant

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -28,6 +28,7 @@
           - ansible-network/frr
           - ansible-network/juniper_junos
           - ansible-network/linux_network
+          - ansible-network/network_configurator
           - ansible-network/network-image-builder
           - ansible-network/network-runner
           - ansible-network/openstack


### PR DESCRIPTION
We'll be gating this project using zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>