### PR TITLE
Add ansible-network/net_operations to ansible zuul tenant

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -28,6 +28,7 @@
           - ansible-network/frr
           - ansible-network/juniper_junos
           - ansible-network/linux_network
+          - ansible-network/net_operations
           - ansible-network/network_configurator
           - ansible-network/network-image-builder
           - ansible-network/network-runner


### PR DESCRIPTION
We plan on gating this repo with zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>