### PR TITLE
Add ansible-network/configure-vlan to ansible zuul tenant

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -29,6 +29,7 @@
           - ansible-network/cisco_iosxr
           - ansible-network/cisco_nxos
           - ansible-network/configure-system-properties
+          - ansible-network/configure-vlan
           - ansible-network/config_manager
           - ansible-network/frr
           - ansible-network/juniper_junos


### PR DESCRIPTION
We plan on gating PRs with zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>