### PR TITLE
Remove retired cloud_vpn roles from zuul

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -48,26 +48,6 @@
       - ansible-python-jobs
 
 - project:
-    name: github.com/ansible-network/cloud_vpn_aws_vpn_provider
-    templates:
-      - noop-jobs
-
-- project:
-    name: github.com/ansible-network/cloud_vpn_aws_vpn_provisioner
-    templates:
-      - noop-jobs
-
-- project:
-    name: github.com/ansible-network/cloud_vpn_csr_provider
-    templates:
-      - noop-jobs
-
-- project:
-    name: github.com/ansible-network/cloud_vpn_vyos_provider
-    templates:
-      - noop-jobs
-
-- project:
     name: github.com/ansible-network/config_manager
     default-branch: devel
     templates:


### PR DESCRIPTION
We are no longer going to run jobs on these projects, so stop running
noop jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>