### PR TITLE
Remove ansible-network/net_operations jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -76,11 +76,6 @@
         - ansible-tox-py37
 
 - project:
-    name: github.com/ansible-network/net_operations
-    templates:
-      - noop-jobs
-
-- project:
     name: github.com/ansible-network/network_configurator
     default-branch: devel
     templates:


### PR DESCRIPTION
We've retired this project, next step is to remove it from our tenant
configuration for zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>