### PR TITLE
Switch ansible/project-config to use ansible-python-jobs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skipsdist = True
 envlist = linters
 
 [testenv]
+basepython = python3
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
 

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -130,12 +130,8 @@
 
 - project:
     name: github.com/ansible/project-config
-    check:
-      jobs:
-        - tox-linters
-    gate:
-      jobs:
-        - tox-linters
+    templates:
+      - ansible-python-jobs
     promote:
       jobs:
         - windmill-config-deploy:


### PR DESCRIPTION
This gives us python3, which is what everything should be using now.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>