### PR TITLE
Default basepython to python3 for tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skipsdist = True
 envlist = linters
 
 [testenv]
+basepython = python3
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
 


### PR DESCRIPTION
We want all things to be using python3.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>