### PR TITLE
Bring online jobs for ansible/ansible-runner

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -129,6 +129,19 @@
       - noop-jobs
 
 - project:
+    name: github.com/ansible/ansible-runner
+    templates:
+      - system-required
+    check:
+      jobs:
+        - ansible-tox-py27:
+            voting: false
+        - ansible-tox-py36:
+            voting: false
+        - ansible-tox-py37:
+            voting: false
+
+- project:
     name: github.com/ansible/project-config
     templates:
       - ansible-python-jobs


### PR DESCRIPTION
Now that ansible/ansible-runner has our github app installed, we can
start to run some check jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>