### PR TITLE
Add system-required to ansible/project-config

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -144,6 +144,7 @@
 - project:
     name: github.com/ansible/project-config
     templates:
+      - system-required
       - ansible-python-jobs
     check:
       jobs:


### PR DESCRIPTION
All projects should have this.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>