### PR TITLE
Gate ansible/ansible-runner project

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -136,10 +136,14 @@
       jobs:
         - ansible-tox-linters
         - ansible-tox-py27
-        - ansible-tox-py36:
-            voting: false
-        - ansible-tox-py37:
-            voting: false
+        - ansible-tox-py36
+        - ansible-tox-py37
+    gate:
+      jobs:
+        - ansible-tox-linters
+        - ansible-tox-py27
+        - ansible-tox-py36
+        - ansible-tox-py37
 
 - project:
     name: github.com/ansible/project-config


### PR DESCRIPTION
We have remove sf.io integration, and ready to gate ansible-runner with
zuul.ansible.com.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>