### PR TITLE
Add ansible-network/vyos to ansible zuul tenant

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -40,6 +40,7 @@
           - ansible-network/resource_module_planning
           - ansible-network/rhel
           - ansible-network/sandbox
+          - ansible-network/vyos
           - ansible-network/windmill-config
 
           # Don't load any configuration from these projects because we


### PR DESCRIPTION
We want to start gating this project with zuul.ansible.com.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>