### PR TITLE
Add noop jobs to ansible-network/vyos

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -129,6 +129,12 @@
       - noop-jobs
 
 - project:
+    name: github.com/ansible-network/vyos
+    default-branch: devel
+    templates:
+      - noop-jobs
+
+- project:
     name: github.com/ansible/ansible-runner
     templates:
       - system-required


### PR DESCRIPTION
We need to add python-jobs but lets make sure branch projection is first
setup.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>