### PR TITLE
Import ansible-network/yang project

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -40,5 +40,7 @@
   description: Ansible Network VyOS Provider Role
 - project: ansible-network/windmill-config
   description: Ansible configuration files for windmill project
+- project: ansible-network/yang
+  description: Ansible Yang Role
 - project: ansible/network
   description: Ansible collection for network devices

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -43,6 +43,7 @@
           - ansible-network/sandbox
           - ansible-network/vyos
           - ansible-network/windmill-config
+          - ansible-network/yang
 
       git.openstack.org:
         untrusted-projects:


### PR DESCRIPTION
We want to start managing ansible-network/yang under gitops and start
gating this repo with zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>