### PR TITLE
Import ansible-network/network-engine

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -31,6 +31,10 @@
   description: Ansible Network Cisco IOS-XR Provider Role
 - project: ansible-network/content_store
   description: Ansible Network content store role
+- project: ansible-network/network-engine
+  description: |
+    This role provides the foundation for building network roles by providing
+    modules and plugins that are common to all Ansible Network roles.
 - project: ansible-network/network_configurator
   description: Ansible role to configure Tower for network operations
 - project: ansible-network/net_operations

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -32,6 +32,7 @@
           - ansible-network/juniper_junos
           - ansible-network/net_operations
           - ansible-network/network_configurator
+          - ansible-network/network-engine
           - ansible-network/network-image-builder
           - ansible-network/network-runner
           - ansible-network/openstack


### PR DESCRIPTION
We want to both manage via gitops and gate jobs with zuul for
ansible-network/network-engine.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>