### PR TITLE
Add ansible-network/cloud_vpn to ansible zuul tenant

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -27,6 +27,7 @@
           - ansible-network/cisco_ios
           - ansible-network/cisco_iosxr
           - ansible-network/cisco_nxos
+          - ansible-network/cloud_vpn
           - ansible-network/config_manager
           - ansible-network/content_store
           - ansible-network/juniper_junos


### PR DESCRIPTION
We want to gate this repo with zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>