### PR TITLE
Import ansible/molecule into ansible zuul tenant

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -48,6 +48,12 @@
           - ansible-network/windmill-config
           - ansible-network/yang
 
+          # Don't load any configuration from these projects because we
+          # don't gate them, so they could wedge our config.
+          - include: []
+            projects:
+              - ansible/molecule
+
       git.openstack.org:
         untrusted-projects:
           - openstack-infra/zuul-jobs


### PR DESCRIPTION
We want to demo zuul's ability to molecule team, but we also want to do
cross project testing with it. Import it into our tenant so we can start
using it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>