### PR TITLE
Add opendev.org projects

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -64,3 +64,14 @@
               - openstack/windmill
               - openstack/windmill-backup
               - openstack/windmill-ops
+
+      opendev.org:
+        untrusted-projects:
+          - zuul/zuul-jobs
+          # Don't load any configuration from these projects because we
+          # don't gate them, so they could wedge our config.
+          - include: []
+            projects:
+              - windmill/windmill
+              - windmill/windmill-backup
+              - windmill/windmill-ops


### PR DESCRIPTION
Now that we have an opendev.org connection in zuul, we can start to load
projects from it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>