### PR TITLE
Remove git.o.o projects

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -54,17 +54,6 @@
             projects:
               - ansible/molecule
 
-      git.openstack.org:
-        untrusted-projects:
-          - openstack-infra/zuul-jobs
-          # Don't load any configuration from these projects because we
-          # don't gate them, so they could wedge our config.
-          - include: []
-            projects:
-              - openstack/windmill
-              - openstack/windmill-backup
-              - openstack/windmill-ops
-
       opendev.org:
         untrusted-projects:
           - zuul/zuul-jobs


### PR DESCRIPTION
Now that opendev.org connection is working, we can remove these.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>