### PR TITLE
Add ansible-tox-linters to ansible/network

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -231,7 +231,12 @@
     default-branch: devel
     templates:
       - system-required
-      - noop-jobs
+    check:
+      jobs:
+        - ansible-tox-linters
+    gate:
+      jobs:
+        - ansible-tox-linters
 
 - project:
     name: github.com/ansible/project-config


### PR DESCRIPTION
Now that tox.ini is in place for the project, we can switch from noop
jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>