### PR TITLE
Add ansible/awx to ansible zuul tenant

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -53,6 +53,7 @@
           - include: []
             projects:
               - ansible/ansible
+              - ansible/awx
               - ansible/molecule
 
       opendev.org:


### PR DESCRIPTION
We want to start working on migrating ansible/awx to zuul.ansible.com,
but we cannot load any jobs from it, as sf.io is the gatekeeper.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>