### PR TITLE
Don't run playbooks on appliance hosts

### DIFF
--- a/playbooks/base-minimal-test/post-ssh.yaml
+++ b/playbooks/base-minimal-test/post-ssh.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: all:!appliance
   # NOTE(pabelanger): We ignore_errors for the following tasks as not to fail
   # successful jobs.
   ignore_errors: true

--- a/playbooks/base-minimal-test/pre.yaml
+++ b/playbooks/base-minimal-test/pre.yaml
@@ -11,7 +11,7 @@
       include_role:
         name: log-inventory
 
-- hosts: all
+- hosts: all:!appliance
   tasks:
     - name: Run add-build-sshkey role
       include_role:


### PR DESCRIPTION
This is because we likely are using network_cli.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>