### PR TITLE
Move ansible-test-network-integration-eos to periodic pipeline

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -217,7 +217,7 @@
 - project:
     name: github.com/ansible/ansible
     default-branch: devel
-    periodic-1hr:
+    periodic:
       jobs:
         - ansible-test-network-integration-eos:
             branches:
@@ -226,8 +226,6 @@
               - stable-2.7
               - stable-2.6
               - stable-2.5
-    periodic:
-      jobs:
         - ansible-test-network-integration-vyos:
             branches:
               - devel


### PR DESCRIPTION
This is now confirmed to be working.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>