### PR TITLE
Run stable-2.8 / devel network integration jobs every 3 hours

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -217,19 +217,25 @@
 - project:
     name: github.com/ansible/ansible
     default-branch: devel
-    periodic:
+    periodic-3hr:
       jobs:
         - ansible-test-network-integration-eos:
             branches:
               - devel
               - stable-2.8
+        - ansible-test-network-integration-vyos:
+            branches:
+              - devel
+              - stable-2.8
+    periodic:
+      jobs:
+        - ansible-test-network-integration-eos:
+            branches:
               - stable-2.7
               - stable-2.6
               - stable-2.5
         - ansible-test-network-integration-vyos:
             branches:
-              - devel
-              - stable-2.8
               - stable-2.7
               - stable-2.6
               - stable-2.5


### PR DESCRIPTION
Until we are running jobs against ansible/ansible PRs for network
integration tests, run every 3 hours. This will help ensure our jobs are
green while we migrate away from DCI.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>