### PR TITLE
Add github.com reporters to third-party-check pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -257,9 +257,17 @@
         - event: pull_request
           action: comment
           comment: (?i)^\s*recheck\s*$
+    start:
+      github.com:
+        status: pending
+        comment: false
     success:
+      github.com:
+        status: 'success'
       mysql:
     failure:
+      github.com:
+        status: 'failure'
       mysql:
     # Don't report merge-failures to github.com
     merge-failure:


### PR DESCRIPTION
This allows us to report back success / failures to github.com PRs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>