### PR TITLE
Remove periodic-3hr pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -189,20 +189,6 @@
       mysql:
 
 - pipeline:
-    name: periodic-3hr
-    post-review: true
-    description: Jobs in this queue are triggered every 3 hours.
-    manager: independent
-    precedence: low
-    trigger:
-      timer:
-        - time: '0 */3 * * *'
-    success:
-      mysql:
-    failure:
-      mysql:
-
-- pipeline:
     name: unlabel-on-push
     description: |
       If a PR is pushed to and has the gate label, we want to remove that.


### PR DESCRIPTION
Now that we have our github app installed on ansible/ansible, we can
start doing pre-merge testing over this periodic pipeline.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>