### PR TITLE
Add third-party-check-silent pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -259,3 +259,33 @@
     # Don't report merge-failures to github.com
     merge-failure:
       mysql:
+
+- pipeline:
+    name: third-party-check-silent
+    description: |
+      Newly uploaded patchsets to projects that are external to Ansible
+      enter this pipeline to receive an initial +/-1 Verified vote.
+    success-message: Build succeeded (third-party-check pipeline).
+    # TODO(mordred) We should write a document for non-OpenStack developers
+    failure-message: |
+      Build failed (third-party-check pipeline) integration testing with
+      Ansible.
+    manager: independent
+    precedence: low
+    trigger:
+      github.com:
+        - event: pull_request
+          action:
+            - opened
+            - changed
+            - reopened
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s*$
+    success:
+      mysql:
+    failure:
+      mysql:
+    # Don't report merge-failures to github.com
+    merge-failure:
+      mysql:


### PR DESCRIPTION
This works just like third-party-check, but we don't report results back
to github. In this case, we want to run jobs against stable branches,
but tests are currently failing.

This is short term until we get them passing, and then we can remove.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>