### PR TITLE
Set ara_report_executable for ara-report role

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -35,6 +35,7 @@
     post-timeout: 1800
     timeout: 1800
     vars:
+      ara_report_executable: /var/lib/zuul/venv/ansible/2.8/bin/ara
       ara_report_type: html
       ara_report_path: ara-report
       ara_compress_html: false
@@ -57,6 +58,7 @@
     post-timeout: 1800
     timeout: 1800
     vars:
+      ara_report_executable: /var/lib/zuul/venv/ansible/2.8/bin/ara
       ara_report_type: html
       ara_report_path: ara-report
       ara_compress_html: false


### PR DESCRIPTION
This is needed now that we have upgraded to zuul 3.9.0.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>