### PR TITLE
Remove ara-report-fork from base-minimal-test

### DIFF
--- a/playbooks/base-minimal-test/post-logs.yaml
+++ b/playbooks/base-minimal-test/post-logs.yaml
@@ -2,11 +2,9 @@
 - hosts: localhost
   gather_facts: false
   tasks:
-    - name: Run ara-report-fork role
+    - name: Run ara-report role
       include_role:
-        name: ara-report-fork
-      vars:
-        ara_report_executable: /var/lib/zuul/venv/ansible/2.7/bin/ara
+        name: ara-report
 
     - name: Run htmlify-logs role
       include_role:


### PR DESCRIPTION
This is no longer needed.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>