### PR TITLE
Round 2 for ara_report_executable

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -35,6 +35,7 @@
     post-timeout: 1800
     timeout: 1800
     vars:
+      ara_report_executable: "/opt/venv/zuul-ansible/{{ ansible_version.full }}/bin/ara"
       ara_report_type: html
       ara_report_path: ara-report
       ara_compress_html: false
@@ -57,6 +58,7 @@
     post-timeout: 1800
     timeout: 1800
     vars:
+      ara_report_executable: "/opt/venv/zuul-ansible/{{ ansible_version.full }}/bin/ara"
       ara_report_type: html
       ara_report_path: ara-report
       ara_compress_html: false


### PR DESCRIPTION
This time use ansible_version to help identify the version of ansible a
job is using, over hardcoding it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>