### PR TITLE
Add ansible-community/ansible-bender to ansible zuul tenant

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -54,6 +54,7 @@
             projects:
               - ansible/ansible
               - ansible/awx
+              - ansible-community/ansible-bender
               - ansible/molecule
 
       opendev.org:


### PR DESCRIPTION
This onboards ansible-community/ansible-bender into zuul.ansible.com,
but doesn't load any jobs from the project. This is mostly because, we
do not want their jobs to break out tenant.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>