### PR TITLE
Add Zuul manifest to base-test

### DIFF
--- a/playbooks/base-minimal-test/post-logs.yaml
+++ b/playbooks/base-minimal-test/post-logs.yaml
@@ -10,6 +10,10 @@
       include_role:
         name: htmlify-logs
 
+    - name: Run Zuul manifest role
+      include_role:
+        name: generate-zuul-manifest
+
     - name: Run upload-logs-swift role
       include_role:
         name: upload-logs-swift


### PR DESCRIPTION
This role is required for the new "Logs" tab to work on the Zuul
build page.  Test its addition to base-test.