### PR TITLE
Enable tenant.report-build-page

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -8,6 +8,7 @@
     # that are unprotected. This means projects need to enable branch
     # protection to in-tree zuul.yaml files.
     exclude-unprotected-branches: true
+    report-build-page: true
     source:
       github.com:
         config-projects:


### PR DESCRIPTION
This should cause Zuul to now report back the build page to github
rather then logs url directly.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>