### PR TITLE
Set status-url to buildset page for check

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -24,10 +24,12 @@
     success:
       github.com:
         status: 'success'
+        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/buildset/{buildset.uuid}'
       mysql:
     failure:
       github.com:
         status: 'failure'
+        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/buildset/{buildset.uuid}'
       mysql:
 
 - pipeline:


### PR DESCRIPTION
Experiment with getting github status to use our new shiny builds page.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>