### PR TITLE
Use status-url for all pipeline reporters

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -68,11 +68,13 @@
     success:
       github.com:
         status: 'success'
+        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/buildset/{buildset.uuid}'
         merge: true
       mysql:
     failure:
       github.com:
         status: 'failure'
+        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/buildset/{buildset.uuid}'
       mysql:
     window-floor: 20
     window-increase-factor: 2
@@ -272,10 +274,12 @@
     success:
       github.com:
         status: 'success'
+        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/buildset/{buildset.uuid}'
       mysql:
     failure:
       github.com:
         status: 'failure'
+        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/buildset/{buildset.uuid}'
       mysql:
     # Don't report merge-failures to github.com
     merge-failure:


### PR DESCRIPTION
Now that we have confirmed this to work, we can properly report back to
github our buildset page.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>