### PR TITLE
Switch to ansible-python-jobs for network collections

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -14,27 +14,27 @@
 - project:
     name: github.com/ansible-network/ansible_collections.arista.eos
     templates:
-      - noop-jobs
+      - ansible-python-jobs
 
 - project:
     name: github.com/ansible-network/ansible_collections.cisco.ios
     templates:
-      - noop-jobs
+      - ansible-python-jobs
 
 - project:
     name: github.com/ansible-network/ansible_collections.cisco.iosxr
     templates:
-      - noop-jobs
+      - ansible-python-jobs
 
 - project:
     name: github.com/ansible-network/ansible_collections.juniper.junos
     templates:
-      - noop-jobs
+      - ansible-python-jobs
 
 - project:
     name: github.com/ansible-network/ansible_collections.vyos.vyos
     templates:
-      - noop-jobs
+      - ansible-python-jobs
 
 - project:
     name: github.com/ansible-network/arista_eos


### PR DESCRIPTION
This drops noop-jobs as we are ready to gate on lint checks.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>