### PR TITLE
Add ansible-network/ansible_collections.network.cli to zuul

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -35,6 +35,8 @@
   description: Ansible Network Collection for Cisco IOSXR
 - project: ansible-network/ansible_collections.juniper.junos
   description: Ansible Network Collection for Juniper JunOS
+- project: ansible-network/ansible_collections.network.cli
+  description: Ansible Network Collection for Network CLI
 - project: ansible-network/ansible_collections.vyos.vyos
   description: Ansible Network Collection for VyOS
 - project: ansible-network/backup_config

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -24,6 +24,7 @@
           - ansible-network/ansible_collections.cisco.ios
           - ansible-network/ansible_collections.cisco.iosxr
           - ansible-network/ansible_collections.juniper.junos
+          - ansible-network/ansible_collections.network.cli
           - ansible-network/ansible_collections.vyos.vyos
           - ansible-network/arista_eos
           - ansible-network/aws


### PR DESCRIPTION
This is part of our collections effort, we want to start testing
network.cli.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>