### PR TITLE
Add more network integration tests to collections

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -14,21 +14,25 @@
 - project:
     name: github.com/ansible-network/ansible_collections.arista.eos
     templates:
+      - ansible-collections-arista-eos
       - ansible-python-jobs
 
 - project:
     name: github.com/ansible-network/ansible_collections.cisco.ios
     templates:
+      - ansible-collections-cisco-ios
       - ansible-python-jobs
 
 - project:
     name: github.com/ansible-network/ansible_collections.cisco.iosxr
     templates:
+      - ansible-collections-cisco-iosxr
       - ansible-python-jobs
 
 - project:
     name: github.com/ansible-network/ansible_collections.juniper.junos
     templates:
+      - ansible-collections-juniper-junos
       - ansible-python-jobs
 
 - project:


### PR DESCRIPTION
Start gating eos, ios, iosxr and junos for network integration tests.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>