### PR TITLE
Add ansible-network/network_content_collector to zuul tenant

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -55,6 +55,8 @@
     modules and plugins that are common to all Ansible Network roles.
 - project: ansible-network/network_configurator
   description: Ansible role to configure Tower for network operations
+- project: ansible-network/network_content_collector
+  description: Ansible Network content creator for collections
 - project: ansible-network/net_operations
   archived: true
   description: RETIRED, Ansible role for network operations automation

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -40,6 +40,7 @@
           - ansible-network/juniper_junos
           - ansible-network/net_operations
           - ansible-network/network_configurator
+          - ansible-network/network_content_collector
           - ansible-network/network-engine
           - ansible-network/network-image-builder
           - ansible-network/network-runner


### PR DESCRIPTION
We'll be using this to mass migrate our network collections.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>