### PR TITLE
Cap git-pull-request to 3.0.0

### DIFF
--- a/playbooks/propose-github-updates/post.yaml
+++ b/playbooks/propose-github-updates/post.yaml
@@ -7,7 +7,7 @@
         dest: ~/.netrc
         mode: 0600
     - name: Install git-pull-request
-      shell: pip3 install git-pull-request --user
+      shell: pip3 install "git-pull-request<3.0.0" --user
 
     - name: Create pull request
       args:


### PR DESCRIPTION
This otherwise, netrc doesn't work. The fix here, is to switch to SSH
keys.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>