### PR TITLE
Remove network.netconf integration jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -43,8 +43,6 @@
 - project:
     name: github.com/ansible-network/ansible_collections.network.netconf
     templates:
-      - ansible-collections-cisco-iosxr
-      - ansible-collections-juniper-junos
       - ansible-python-jobs
 
 - project:


### PR DESCRIPTION
These are the wrong jobs we want to test with.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>