### PR TITLE
Partitions swift containers for logs

### DIFF
--- a/playbooks/base-minimal-test/post-logs.yaml
+++ b/playbooks/base-minimal-test/post-logs.yaml
@@ -20,6 +20,8 @@
           include_role:
             name: upload-logs-swift
           vars:
+            zuul_log_partition: true
+            zuul_log_container: ansible
             zuul_log_cloud_config: "{{ vexxhost_clouds_yaml }}"
       rescue:
         # NOTE(pabelanger): If for some reason we cannot upload logs, try
@@ -28,16 +30,6 @@
           include_role:
             name: upload-logs-swift
           vars:
+            zuul_log_partition: true
+            zuul_log_container: ansible
             zuul_log_cloud_config: "{{ vexxhost_clouds_yaml }}"
-
-    # NOTE(pabelanger): We should update upload-logs-swift role to accept a
-    # zuul_log_url variable so we don't have to do this.
-    - name: Setup log path fact
-      include_role:
-        name: set-zuul-log-path-fact
-
-    - name: Return log URL to Zuul
-      zuul_return:
-        data:
-          zuul:
-            log_url: "https://logs.zuul.ansible.com/{{ zuul_log_path }}/"


### PR DESCRIPTION
We are dealing with POST_FAILUREs in vexxhost when uploading logs to
swift, it was suggested we try hash our logs across containers, to help
with these timeouts.

This means, we now drop logs.z.a.c from our log_url.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>