### PR TITLE
Promote base-minimal-test changes

### DIFF
--- a/playbooks/base-minimal/post-logs.yaml
+++ b/playbooks/base-minimal/post-logs.yaml
@@ -20,6 +20,8 @@
           include_role:
             name: upload-logs-swift
           vars:
+            zuul_log_partition: true
+            zuul_log_container: ansible
             zuul_log_cloud_config: "{{ vexxhost_clouds_yaml }}"
       rescue:
         # NOTE(pabelanger): If for some reason we cannot upload logs, try
@@ -28,16 +30,6 @@
           include_role:
             name: upload-logs-swift
           vars:
+            zuul_log_partition: true
+            zuul_log_container: ansible
             zuul_log_cloud_config: "{{ vexxhost_clouds_yaml }}"
-
-    # NOTE(pabelanger): We should update upload-logs-swift role to accept a
-    # zuul_log_url variable so we don't have to do this.
-    - name: Setup log path fact
-      include_role:
-        name: set-zuul-log-path-fact
-
-    - name: Return log URL to Zuul
-      zuul_return:
-        data:
-          zuul:
-            log_url: "https://logs.zuul.ansible.com/{{ zuul_log_path }}/"


### PR DESCRIPTION
This removes using logs.z.a.c as the hostname to browse logs, it also
hashes our logs creating more swift containers.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>