### PR TITLE
Experiment using rackspace DFW for swift logs

### DIFF
--- a/playbooks/base-minimal-test/post-logs.yaml
+++ b/playbooks/base-minimal-test/post-logs.yaml
@@ -14,22 +14,12 @@
       include_role:
         name: generate-zuul-manifest
 
-    - name: Upload logs to swift
-      block:
-        - name: Run upload-logs-swift role
-          include_role:
-            name: upload-logs-swift
-          vars:
-            zuul_log_partition: true
-            zuul_log_container: ansible
-            zuul_log_cloud_config: "{{ vexxhost_clouds_yaml }}"
-      rescue:
-        # NOTE(pabelanger): If for some reason we cannot upload logs, try
-        # again. It is possible network issue on remote side.
-        - name: Run upload-logs-swift role
-          include_role:
-            name: upload-logs-swift
-          vars:
-            zuul_log_partition: true
-            zuul_log_container: ansible
-            zuul_log_cloud_config: "{{ vexxhost_clouds_yaml }}"
+    - name: Run upload-logs-swift role
+      include_role:
+        name: upload-logs-swift
+      vars:
+        zuul_log_partition: true
+        zuul_log_container: ansible
+        zuul_log_cloud_config: "{{ item }}"
+      with_random_choice:
+        - "{{ rackspace_dfw_clouds_yaml }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -63,6 +63,7 @@
       ara_report_path: ara-report
       ara_compress_html: false
     secrets:
+      - rackspace_dfw_clouds_yaml
       - vexxhost_clouds_yaml
     nodeset: centos-7-1vcpu
 

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -2,6 +2,46 @@
 #   tools/encrypt_secret.py --infile in.txt --outfile out.txt --tenant ansible https://dashboard.zuul.ansible.com ansible/project-config
 ---
 - secret:
+    name: rackspace_dfw_clouds_yaml
+    data:
+      profile: rackspace
+      auth:
+        username: !encrypted/pkcs1-oaep
+          - Cy/bT4lVS6H0zQT0x1mW15hDgS0if0T6g5BnWVxPL1cmm6brR9fCFZOVIusBwGNuYxvpw
+            aLQtirsFdTjJIghGta2XUyjIPXVCQRuSVukBLlhXn5vUL8vRpVr3zuAokihQmiLGufuhN
+            ++Vh5MGN3Jt9OmQGBBSpj5XR2NcKRrlqk7W3wkM/RNRUV0tfjxWN3ttOAZx10j4T6zOfN
+            1zneSWJkBvhL0YoQt++f5E53fDkZwH2zqlbicUc5+KogT/Z8wmQTSLKdfpkFfYUtDi9EX
+            tHSPaYLNv+WW4DvBP4nzVa0JsBE0zYoI2krYlV+ShM1ykGuaDbdBGDZDthl6mITQNO+OY
+            AA3ssLuVpf6a8dGgyN+PUcjN2VcNw+pktpGMV0rkAWnIShXNupYzRPmzvZEoeaDaECKZ4
+            k8Rx5e+VEWCqGcJndhZJ7rTia5Bzo86lrH5OMg/q76wIgfXLYe1kdvrdqeZk9w2jOPU3E
+            9gA6R61D0vTwBmQ8XDl2acU+1u8JYuq8KwmVHsam2Iz3ehN6UrP4w3MUiE2UUn+F2errZ
+            FhYe4Ff10NVfFWCAzwhn+Tv/z1YdtZyIAXRY7x1Rn3BVFlwOP7xGFKyAeXxjBL+zWEUzv
+            g4wZZQz7Pc0OKxBHT6PfAz7GaCsS6ixt1HkQu2j3107akQR+1xy+shiBa7v8Q8=
+        password: !encrypted/pkcs1-oaep
+          - mpe+YuivV0y45HIRdXmgyBZDwxgLtF8nh6xz2VJgiaoswgGdP+VjqH/zJ7s2B6ggttv7L
+            L1rGLuGVBLMWbLJaQTCeCCZe4/nVKGscZf4H5y2Q8CdJI+BfWYPcxVHx0MGHgkDtIsM3I
+            ShrNCD68bFo2wjrWIRxOoxJRqeCrPuU2VIJrE5f5gIxb5zhmUAz4gMxzO6NYkXsq4yyYQ
+            HJzg49zbfupH86LfWbBIswh7mfZHligXRjapIA5wUrdjQtzKs41JyNS1mt/uKKwDX2QPG
+            4+f9dGyQgU+9pAt34GOpP7AIB9+t9IWCDwEdRfaCRZ0uHGxhIzkBExdaMWxk9AKpPOCks
+            474wuixJRqEsgbscz9pQv3nN1RDTdf8YZIa/83drgsTiD6+FSbiawG5uhFzjx9qovINZN
+            cOJidVPL1fjXDVcTAHfcgp0edcGEHczTOR1e/ihz5WaAO+hPLWPYS4/mG0W+h/DoUE7qh
+            sQ36JgipX3mYXnm0pZ+uKeeLtk0+Ye+dWWPlkQnzGtrBxnwz3woid59x2cSCx3KtGlik+
+            eXNzgwG6IajjlxM8iDFXTrfkwZ394kqDf5oBBKC5NNndD/lQhEanIykiVefPQ8L7qDVM+
+            pmIGZVCikKzpIPj5FOWBSRQdZJp1QaaTKG2N/SpPC4Ja8NbubLkBfwXRXoyegQ=
+        project_name: !encrypted/pkcs1-oaep
+          - C35Mbw7XbYchXgUrQ+339Ifre0hI2cANgfXG5PwYwrDZ3CqI+FOXHsgpHeG5LRajAKqAo
+            ODBbQ3gwFhYfiX8wwdHLLaXaFk8wI5wGj0vd+YkDXDZNedjTpBmBw4uiOpjyOHeTW9J8V
+            KO7C03c0pI4CoN/BaR+oS/FSin/qmwl3Z4jTzkrETHZwPBic/GIgPzJqM7SMjnGGx0uZT
+            ZP/jOwLyiNXiB34OwXXLOvAt+q5Eiw+cExoSo4yq/+ysiI4i7bxKRsXTbnq2v61S1vK1v
+            g0PxDGhG7naT5HJUMJRnTbGuR1rT6VZpzJEEwsYl1FiraNYeCwsSZVmVdG6l89fzQBBsP
+            h/CmjkC8/oMsktvlTXcKc1XR7R+XHJTAb3JuzFbgZU5cFg5lLHrRzUrw16ntiXxaAdt82
+            hD82dTlmjriwZkBioD2hkq/LrS/uFa9dEhuGmioXmNk7v9e6cMYRiKkoNEurcgpcQVJG/
+            UGgQoQqpZcC7XN0dPd2hucSSH8X9P/iJQisZ5wueUwUv1P4+cEtBs7kfWeSJw5v4eeZ2d
+            6nUcjbr8mAtSDg32rjheCc7yZaRg7MXWc6K1XipsmyC+Pqr2Fg3q9ISIYJiTiBJSJqf8K
+            QKJU5ir1JseY7XkayjhbC3OXxvQCES03Ld79D837JvEwgvVDZgbK7qdQO4ynJc=
+      region_name: DFW
+
+- secret:
     name: vexxhost_clouds_yaml
     data:
       auth_type: password


### PR DESCRIPTION
This will add a 2nd cloud, for logs storage, to help minimize our
POST_FAILUREs we are seeing when we have issues with swift.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>