### PR TITLE
Add ansible-network/ansible_collections.cisco.nxos to zuul

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -33,6 +33,8 @@
   description: Ansible Network Collection for Cisco IOS
 - project: ansible-network/ansible_collections.cisco.iosxr
   description: Ansible Network Collection for Cisco IOSXR
+- project: ansible-network/ansible_collections.cisco.nxos
+  description: Ansible Network Collection for Cisco NXOS
 - project: ansible-network/ansible_collections.juniper.junos
   description: Ansible Network Collection for Juniper JunOS
 - project: ansible-network/ansible_collections.network.cli

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -23,6 +23,7 @@
           - ansible-network/ansible_collections.arista.eos
           - ansible-network/ansible_collections.cisco.ios
           - ansible-network/ansible_collections.cisco.iosxr
+          - ansible-network/ansible_collections.cisco.nxos
           - ansible-network/ansible_collections.juniper.junos
           - ansible-network/ansible_collections.network.cli
           - ansible-network/ansible_collections.network.netconf


### PR DESCRIPTION
We'll be using this for our new cisco.nxos collection.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>