### PR TITLE
Add linter jobs to ansible-security/ids_config

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -273,8 +273,12 @@
 
 - project:
     name: github.com/ansible-security/ids_config
-    templates:
-      - noop-jobs
+    check:
+      jobs:
+        - ansible-tox-linters
+    gate:
+      jobs:
+        - ansible-tox-linters
 
 - project:
     name: github.com/ansible/ansible


### PR DESCRIPTION
This moves our common jobs to central config.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>