### PR TITLE
Remove noop jobs from ansible-security/ids_install

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -282,8 +282,12 @@
 
 - project:
     name: github.com/ansible-security/ids_install
-    templates:
-      - noop-jobs
+    check:
+      jobs:
+        - ansible-tox-linters
+    gate:
+      jobs:
+        - ansible-tox-linters
 
 - project:
     name: github.com/ansible/ansible


### PR DESCRIPTION
Now that linter jobs are passing, and stable we can centralize this job
config.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>