### PR TITLE
Add post-run playbook for release-ansible-galaxy-collections

### DIFF
--- a/playbooks/ansible-collection/post.yaml
+++ b/playbooks/ansible-collection/post.yaml
@@ -1,0 +1,23 @@
+---
+- hosts: all
+  tasks:
+    - name: Find tarballs in folder
+      find:
+        file_type: file
+        paths: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+        patterns: "*.tar.gz"
+      register: result
+
+    - name: Ensure artifacts directory exists
+      file:
+        path: "{{ zuul.executor.work_root }}/artifacts"
+        state: directory
+      delegate_to: localhost
+
+    - name: Collect tarball artifacts
+      synchronize:
+        dest: "{{ zuul.executor.work_root }}/artifacts/"
+        mode: pull
+        src: "{{ item.path }}"
+        verify_host: true
+      with_items: "{{ result.files }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -105,4 +105,5 @@
       Release ansible collection to galaxy.
     pre-run: playbooks/ansible-collection/pre.yaml
     run: playbooks/ansible-collection/run.yaml
+    post-run: playbooks/ansible-collection/post.yaml
     nodeset: centos-8-1vcpu


### PR DESCRIPTION
This allows us to sync back the new collection to the executor, the next
step in publishing the job.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>