### PR TITLE
Dynamically version our collections based on git info

### DIFF
--- a/playbooks/ansible-collection/run-pre.yaml
+++ b/playbooks/ansible-collection/run-pre.yaml
@@ -1,0 +1,15 @@
+---
+- hosts: all
+  tasks:
+    - name: Setup tox role
+      include_role:
+        name: tox
+      vars:
+        tox_extra_args: -vv --notest
+        tox_install_siblings: false
+        zuul_work_dir: "{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
+
+    - name: Generate version number for ansible collection.
+      args:
+        chdir: "{{ zuul.project.src_dir }}"
+      command: "{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/generate-ansible-collection"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -104,6 +104,10 @@
     description: |
       Release ansible collection to galaxy.
     pre-run: playbooks/ansible-collection/pre.yaml
-    run: playbooks/ansible-collection/run.yaml
+    run:
+      - playbooks/ansible-collection/run-pre.yaml
+      - playbooks/ansible-collection/run.yaml
     post-run: playbooks/ansible-collection/post.yaml
+    required-projects:
+      - github.com/ansible-network/releases
     nodeset: centos-8-1vcpu


### PR DESCRIPTION
This allows us to remove hardcoded version numbers and get to a point
where we can publish latest master to galaxy.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>