### PR TITLE
Publish vyos.vyos collection to ansible galaxy

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -57,6 +57,7 @@
     templates:
       - ansible-collections-vyos-vyos
       - ansible-python-jobs
+      - publish-to-galaxy
 
 - project:
     name: github.com/ansible-network/arista_eos


### PR DESCRIPTION
We are now ready to do per commit releases to ansible galaxy.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/240
Signed-off-by: Paul Belanger <pabelanger@redhat.com>