### PR TITLE
Add ansible-security/ansible_collections.ibm.qradar to zuul

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -74,6 +74,8 @@
   description: Ansible Yang Role
 - project: ansible-network/zuul-config
   description: Repo containing Zuul project configuration
+- project: ansible-security/ansible_collections.ibm.qradar
+  description: IBM QRadar Ansible Collection
 - project: ansible-security/ids_config
   description: Ansible role to provide configuration Intrusion Detection Systems
 - project: ansible-security/ids_install

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -58,6 +58,7 @@
           - ansible-network/vyos
           - ansible-network/windmill-config
           - ansible-network/yang
+          - ansible-security/ansible_collections.ibm.qradar
           - ansible-security/ids_config
           - ansible-security/ids_install
 


### PR DESCRIPTION
Bring online ansible-security/ansible_collections.ibm.qradar for ansible
tenant, we plan to start to run more testing against it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>