### PR TITLE
Use publish-to-galaxy-master-only job for network collections

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -16,40 +16,40 @@
     templates:
       - ansible-collections-arista-eos
       - ansible-python-jobs
-      - publish-to-galaxy
+      - publish-to-galaxy-master-only
 
 - project:
     name: github.com/ansible-network/ansible_collections.cisco.ios
     templates:
       - ansible-collections-cisco-ios
       - ansible-python-jobs
-      - publish-to-galaxy
+      - publish-to-galaxy-master-only
 
 - project:
     name: github.com/ansible-network/ansible_collections.cisco.iosxr
     templates:
       - ansible-collections-cisco-iosxr
       - ansible-python-jobs
-      - publish-to-galaxy
+      - publish-to-galaxy-master-only
 
 - project:
     name: github.com/ansible-network/ansible_collections.cisco.nxos
     templates:
       - ansible-python-jobs
-      - publish-to-galaxy
+      - publish-to-galaxy-master-only
 
 - project:
     name: github.com/ansible-network/ansible_collections.juniper.junos
     templates:
       - ansible-collections-juniper-junos
       - ansible-python-jobs
-      - publish-to-galaxy
+      - publish-to-galaxy-master-only
 
 - project:
     name: github.com/ansible-network/ansible_collections.network.cli
     templates:
       - ansible-python-jobs
-      - publish-to-galaxy
+      - publish-to-galaxy-master-only
 
 - project:
     name: github.com/ansible-network/ansible_collections.network.netconf
@@ -57,14 +57,14 @@
       - ansible-collections-cisco-iosxr-netconf
       - ansible-collections-juniper-junos-netconf
       - ansible-python-jobs
-      - publish-to-galaxy
+      - publish-to-galaxy-master-only
 
 - project:
     name: github.com/ansible-network/ansible_collections.vyos.vyos
     templates:
       - ansible-collections-vyos-vyos
       - ansible-python-jobs
-      - publish-to-galaxy
+      - publish-to-galaxy-master-only
 
 - project:
     name: github.com/ansible-network/arista_eos


### PR DESCRIPTION
Until we figure out what to do with stable branch jobs, only publish
master.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/241
Signed-off-by: Paul Belanger <pabelanger@redhat.com>