### PR TITLE
Add ansible-network/network_collections_migration to zuul

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -57,6 +57,8 @@
   description: >-
     This role provides the foundation for building network roles by providing
     modules and plugins that are common to all Ansible Network roles.
+- project: ansible-network/network_collections_migration
+  description: Supported Ansible Network collections and migration scenarios
 - project: ansible-network/network_configurator
   description: Ansible role to configure Tower for network operations
 - project: ansible-network/network_content_collector

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -42,6 +42,7 @@
           - ansible-network/content_store
           - ansible-network/juniper_junos
           - ansible-network/net_operations
+          - ansible-network/network_collections_migration
           - ansible-network/network_configurator
           - ansible-network/network_content_collector
           - ansible-network/network-engine


### PR DESCRIPTION
We'll be using this repo to drive our network collection migrations now.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>