### PR TITLE
Add noop jobs for ansible-security/ansible_collections.ibm.qradar

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -289,6 +289,11 @@
         - ansible-tox-py27
 
 - project:
+    name: github.com/ansible-security/ansible_collections.ibm.qradar
+    templates:
+      - noop-jobs
+
+- project:
     name: github.com/ansible-security/ids_config
     check:
       jobs:


### PR DESCRIPTION
This adds noop jobs to start to gate the ibm.qradar.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>