### PR TITLE
Publish qradar collections to galaxy

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -292,6 +292,7 @@
     name: github.com/ansible-security/ansible_collections.ibm.qradar
     templates:
       - noop-jobs
+      - publish-to-galaxy-master-only
 
 - project:
     name: github.com/ansible-security/ids_config


### PR DESCRIPTION
Now that zuul is setup to gate the repo, using noop jobs, we can start
to publish content to galaxy.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>