### PR TITLE
prepare-workspace-git only on controller node

### DIFF
--- a/playbooks/base-minimal-test/pre.yaml
+++ b/playbooks/base-minimal-test/pre.yaml
@@ -22,6 +22,8 @@
       include_role:
         name: start-zuul-console
 
+- hosts: controller
+  tasks:
     - name: Run prepare-workspace-git role
       include_role:
         name: prepare-workspace-git

--- a/playbooks/base-minimal/pre.yaml
+++ b/playbooks/base-minimal/pre.yaml
@@ -22,6 +22,8 @@
       include_role:
         name: start-zuul-console
 
+- hosts: controller
+  tasks:
     - name: Run prepare-workspace-git role
       include_role:
         name: prepare-workspace-git


### PR DESCRIPTION
The other nodes don't necessary have git, not need the workspace copy locally.