### PR TITLE
Switch ibm.qradar collection to publish-to-galaxy

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -303,7 +303,7 @@
     name: github.com/ansible-security/ansible_collections.ibm.qradar
     templates:
       - noop-jobs
-      - publish-to-galaxy-master-only
+      - publish-to-galaxy
 
 - project:
     name: github.com/ansible-security/ids_config


### PR DESCRIPTION
We only have a a master branch for ibm.qradar, this fixes a bug with
release / pre-release jobs only happening on master branches.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>