### PR TITLE
Add ansible/galaxy to zuul ansible tenant

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -72,6 +72,7 @@
               - ansible/ansible-bare
               - ansible-community/collection_migration
               - ansible/awx
+              - ansible/galaxy
               - ansible/molecule
               - metal3-io/metal3-dev-env
 


### PR DESCRIPTION
We won't gate ansible/galaxy, but we do want to be able to run a
buildset-galaxy server.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>