### PR TITLE
Add ansible-network/ansible_collections.ansible.netcommon to zuul

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -27,6 +27,8 @@
   description: ansible-playbook + buildah = a sweet container image
 - project: ansible-network/ansible-zuul-jobs
   description: Defines test jobs and roles
+- project: ansible-network/ansible_collections.ansible.netcommon
+  description: Ansible Network Collection for Common Code
 - project: ansible-network/ansible_collections.arista.eos
   description: Ansible Network Collection for Arista EOS
 - project: ansible-network/ansible_collections.cisco.ios

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -21,6 +21,7 @@
           - ansible/ansible-runner
           - ansible-community/ansible-bender
           - ansible/network
+          - ansible-network/ansible_collections.ansible.netcommon
           - ansible-network/ansible_collections.arista.eos
           - ansible-network/ansible_collections.cisco.ios
           - ansible-network/ansible_collections.cisco.iosxr


### PR DESCRIPTION
This is now our common network collection.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>