### PR TITLE
Add ansible-network/collection_migration into zuul

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -53,6 +53,8 @@
   description: Ansible Network Cisco IOS-XR Provider Role
 - project: ansible-network/cloud_vpn
   description: Ansible Cloud VPN Role
+- project: ansible-network/collection_migration
+  description: scripts and scenarios for migration from core code to collections
 - project: ansible-network/community.netcommon
   description: Ansible Network Collection for Common Code
 - project: ansible-network/content_store

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -39,6 +39,7 @@
           - ansible-network/cisco_iosxr
           - ansible-network/cisco_nxos
           - ansible-network/cloud_vpn
+          - ansible-network/collection_migration
           - ansible-network/community.netcommon
           - ansible-network/config_manager
           - ansible-network/content_store


### PR DESCRIPTION
This fork will be used, so we can carry patches needed to produce
network collections. We'll continue to sync from upstream on a
regularly.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>