### PR TITLE
Add noop jobs to ansible-network/collection_migration

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -151,6 +151,11 @@
         - ansible-tox-linters
 
 - project:
+    name: github.com/ansible-network/collection_migration
+    templates:
+      - noop-jobs
+
+- project:
     name: github.com/ansible-network/community.netcommon
     templates:
       - ansible-python-jobs


### PR DESCRIPTION
This allows us to gate commits on the new repo.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>