### PR TITLE
Added molecule related projects to Zuul

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -78,6 +78,8 @@
               - ansible/molecule
               - ansible/workshops
               - metal3-io/metal3-dev-env
+              - pycontribs/pytest-molecule
+              - pycontribs/selinux
 
       github-3pci:
         untrusted-projects:


### PR DESCRIPTION
Both pytest-molecule and selinux (shim) are usually used with module
itself, first enables pytest to detect and run scenarios as tests and
the second gives access to system selinux from inside a virtualenv,
allowing us to run ansible from isolated virtualenvs on selinux enabled
systems.

Needed-By: https://github.com/pycontribs/pytest-molecule/pull/53