### PR TITLE
Remove metal3-io/metal3-dev-env

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -77,7 +77,6 @@
               - ansible/galaxy
               - ansible/molecule
               - ansible/workshops
-              - metal3-io/metal3-dev-env
               - pycontribs/pytest-molecule
               - pycontribs/selinux
 


### PR DESCRIPTION
The POC is over, lets remove this.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>