### PR TITLE
Add molecule-containers project

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -29,6 +29,8 @@
   description: Molecule aids in the development and testing of Ansible roles
 - project: ansible-community/molecule-azure
   description: Molecule Azure Driver Plugin
+- project: ansible-community/molecule-containers
+  description: Molecule Containers Driver Plugin
 - project: ansible-community/molecule-digitalocean
   description: molecule-digitalocean
 - project: ansible-community/molecule-ec2

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -22,6 +22,7 @@
           - ansible-community/ansible-bender
           - ansible-community/molecule
           - ansible-community/molecule-azure
+          - ansible-community/molecule-containers
           - ansible-community/molecule-digitalocean
           - ansible-community/molecule-ec2
           # - ansible-community/molecule-gce


### PR DESCRIPTION
Adds all molecule drivers to ansible-community as part of migrating them from their temporary location at pycontribs.