### PR TITLE
Correct pending status-url

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -19,7 +19,7 @@
     start:
       github.com:
         status: 'pending'
-        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/status'
+        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/status/change/{change.number},{change.patchset}'
         comment: false
     success:
       github.com:


### PR DESCRIPTION
Instead of sending user to the generic dashboard it will open the page where he can see the status of the jobs related to his change.