### PR TITLE
Remove noop jobs from ansible-network/network_collections_migration

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -187,11 +187,6 @@
         - ansible-tox-py27
 
 - project:
-    name: github.com/ansible-network/network_collections_migration
-    templates:
-      - noop-jobs
-
-- project:
     name: github.com/ansible-network/network_configurator
     default-branch: devel
     templates:


### PR DESCRIPTION
We now have github-workflow jobs that can gate for us, we also have
in-tree jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>