### PR TITLE
Add ansible-collections-cisco-iosxr-netconf to ansible.netcommon

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -18,6 +18,7 @@
 - project:
     name: github.com/ansible-network/ansible_collections.ansible.netcommon
     templates:
+      - ansible-collections-cisco-iosxr-netconf
       - ansible-python-jobs
       - integrated-queue
       - publish-to-galaxy-master-only


### PR DESCRIPTION
Bring online iosxr netconf testing for ansible.netcommon collection.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>