### PR TITLE
Retire ansible-network/ansible_collections.juniper.junos

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -38,7 +38,8 @@
 - project: ansible-network/ansible_collections.cisco.nxos
   description: Ansible Network Collection for Cisco NXOS
 - project: ansible-network/ansible_collections.juniper.junos
-  description: Ansible Network Collection for Juniper JunOS
+  archived: true
+  description: RETIRED, Ansible Network Collection for Juniper JunOS
 - project: ansible-network/ansible_collections.junipernetworks.junos
   description: Ansible Network Collection for Juniper JunOS
 - project: ansible-network/ansible_collections.network.cli

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -37,7 +37,6 @@
           - ansible-network/ansible_collections.cisco.ios
           - ansible-network/ansible_collections.cisco.iosxr
           - ansible-network/ansible_collections.cisco.nxos
-          - ansible-network/ansible_collections.juniper.junos
           - ansible-network/ansible_collections.junipernetworks.junos
           - ansible-network/ansible_collections.network.cli
           - ansible-network/ansible_collections.network.netconf


### PR DESCRIPTION
Now that this is retired, we can remove it from zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>