### PR TITLE
Update github status-url across the board

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -63,7 +63,7 @@
     start:
       github.com:
         status: 'pending'
-        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/status'
+        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/status/change/{change.number},{change.patchset}'
         comment: false
     success:
       github.com:
@@ -283,7 +283,7 @@
     start:
       github.com:
         status: pending
-        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/status'
+        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/status/change/{change.number},{change.patchset}'
         comment: false
     success:
       github.com:
@@ -324,7 +324,7 @@
     start:
       github-3pci:
         status: pending
-        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/status'
+        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/status/change/{change.number},{change.patchset}'
         comment: false
     success:
       github-3pci:


### PR DESCRIPTION
Now that we know the pending status-url works, we can make the change to
all other pipelines.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>