### PR TITLE
Switch jobs to centos-8 over fedora-latest

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -81,7 +81,7 @@
       tox env.
     vars:
       tox_envlist: github
-    nodeset: fedora-latest-1vcpu
+    nodeset: centos-8-1vcpu
     files:
       - github/projects.yaml
       - requirements.txt
@@ -97,7 +97,7 @@
     post-run: playbooks/propose-github-updates/post.yaml
     secrets:
       - github_proposal_bot
-    nodeset: fedora-latest-1vcpu
+    nodeset: centos-8-1vcpu
 
 - job:
     name: build-ansible-collection


### PR DESCRIPTION
Fedora nodes are replaced every 6 months, by moving to centos-8,
hopefully we have less churn at OS level.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>