### PR TITLE
Remove ansible/molecule from zuul

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -19,7 +19,6 @@
           # After this point, sorting projects alphabetically will help
           # merge conflicts
           - ansible/ansible-runner
-          - ansible/molecule
           - ansible-community/ansible-bender
           - ansible-community/molecule-azure
           - ansible-community/molecule-digitalocean


### PR DESCRIPTION
This is because we are migrating it to another namespace.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>