### PR TITLE
Add ansible-community/molecule to zuul

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -25,6 +25,8 @@
 ---
 - project: ansible-community/ansible-bender
   description: ansible-playbook + buildah = a sweet container image
+- project: ansible-community/molecule
+  description: Molecule aids in the development and testing of Ansible roles
 - project: ansible-community/molecule-azure
   description: Molecule Azure Driver Plugin
 - project: ansible-community/molecule-digitalocean

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -20,6 +20,7 @@
           # merge conflicts
           - ansible/ansible-runner
           - ansible-community/ansible-bender
+          - ansible-community/molecule
           - ansible-community/molecule-azure
           - ansible-community/molecule-digitalocean
           - ansible-community/molecule-ec2


### PR DESCRIPTION
Now that molecule has moved, we can onboard it into zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>