### PR TITLE
Install twine into virtualenv for pypi-upload job

### DIFF
--- a/playbooks/publish/pypi.yaml
+++ b/playbooks/publish/pypi.yaml
@@ -1,8 +1,19 @@
 ---
 - hosts: localhost
   roles:
-    - role: ensure-twine
-      when: zuul_success | bool
-    - role: upload-pypi
-      pypi_path: "{{ zuul.executor.work_root }}/artifacts"
+    - name: Publish artifacts to pypi
+      block:
+        - name: Create virtualenv for twine
+          shell: virtualenv --python python3 ~/venv
+
+        - name: Install twine into virtualenv
+          shell: ~/venv/bin/pip install twine
+
+        - name: Run upload-pypi role
+          include_role:
+            name: upload-pypi
+          vars:
+            pypi_path: "{{ zuul.executor.work_root }}/artifacts"
+            pypi_twine_executable: ~/venv/bin/twine
+
       when: zuul_success | bool

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -126,7 +126,6 @@
     vars:
       bdist_wheel_xargs: "--universal"
       release_python: python3
-      twine_python: python3
     nodeset: centos-8-1vcpu
 
 - job:


### PR DESCRIPTION
This should help avoid some problems we are having with twine today.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>