### PR TITLE
Update release-ansible-python to publish to pypi.org

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -121,10 +121,9 @@
       - playbooks/build-python-tarball/post.yaml
       - playbooks/publish/pypi.yaml
     secrets:
-      - secret: testpypi_secret
+      - secret: pypi_secret
         name: pypi_info
     vars:
-      bdist_wheel_xargs: "--universal"
       release_python: python3
     nodeset: centos-8-1vcpu
 


### PR DESCRIPTION
Now that we know this job works as expected, we can publish to pypi
directly.

Also drop universal wheels, as some project may not support it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>