### PR TITLE
Add publish-to-pypi to molecule-libvirt

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -39,6 +39,7 @@
     name: github.com/ansible-community/molecule-libvirt
     templates:
       - system-required
+      - publish-to-pypi
 
 - project:
     name: github.com/ansible-community/molecule-vagrant


### PR DESCRIPTION
We are ready to automate release of molecule-libvirt.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/342
Signed-off-by: Paul Belanger <pabelanger@redhat.com>