### PR TITLE
ansible-runner: attaching new job templates

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -363,16 +363,14 @@
     name: github.com/ansible/ansible-runner
     templates:
       - system-required
+      - ansible-python-jobs
       - ansible-python3-jobs
+      - publish-to-pypi
     check:
       jobs:
-        - ansible-build-python-tarball
-        - ansible-tox-linters
         - ansible-tox-py27
     gate:
       jobs:
-        - ansible-build-python-tarball
-        - ansible-tox-linters
         - ansible-tox-py27
 
 - project:


### PR DESCRIPTION
Attaching two new job templates for ansible-runner:

  * ansible-python-jobs
  * publish-to-pypi