### PR TITLE
add virt-lightning/esxi-cloud-images in Zuul

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -113,3 +113,5 @@
   description: Ansible collection for network devices
 - project: ansible/workshops
   description: Training Course for Ansible Automation Platform
+- project: virt-lightning/esxi-cloud-images
+  description: Generate Cloud image of ESXi, as used in Ansible-VMware CI

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -78,6 +78,7 @@
           - ansible-security/ids_config
           - ansible-security/ids_install
           - pycontribs/selinux
+          - virt-lightning/esxi-cloud-images
 
           # Don't load any configuration from these projects because we
           # don't gate them, so they could wedge our config.


### PR DESCRIPTION
Enable Zuul on virt-lightning/esxi-cloud-images. This repository is used
to build the ESXi cloud image.