### PR TITLE
Add auto_init to new projects we create

### DIFF
--- a/tools/manage-projects.py
+++ b/tools/manage-projects.py
@@ -86,6 +86,9 @@ class Client(object):
             LOG.info('Fetching github info about %s', repo_name)
             repo = org.get_repo(repo_name)
         except github.GithubException:
+            # NOTE(pabelanger): We should also allow to import an existing
+            # project from upstream source.
+            kwargs['auto_init'] = True
             LOG.info(
                 'Creating %s in github', repo_name)
             repo = org.create_repo(


### PR DESCRIPTION
While we supported the ability to create a project, we didn't actually
populate the repo.  For now, just use the feature in github until we can
update it with our own function.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>