### PR TITLE
Switch base-minimal-test to use centos-8-1vcpu

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -70,7 +70,7 @@
       - rackspace_iad_clouds_yaml
       - rackspace_ord_clouds_yaml
       - vexxhost_clouds_yaml
-    nodeset: centos-7-1vcpu
+    nodeset: centos-8-1vcpu
 
 # ansible/project-config jobs
 - job:


### PR DESCRIPTION
This allows us to prepare for changing base-minimal to use
centos-8-1vcpu which is needed for taking advantage of newer toolchain
tools in tox jobs, which use nodeset defined by base-minimal.