### PR TITLE
Rename ansible-network/ansible_collections.cisco.ios

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -20,6 +20,15 @@
       - publish-to-galaxy-master-only
 
 - project:
+    name: github.com/ansible-collections/ios
+    templates:
+      - system-required
+      - ansible-collections-cisco-ios
+      - ansible-python-jobs
+      - integrated-queue
+      - publish-to-galaxy-master-only
+
+- project:
     name: github.com/ansible-collections/netcommon
     templates:
       - system-required
@@ -69,14 +78,6 @@
     name: github.com/ansible-community/pytest-molecule
     templates:
       - system-required
-
-- project:
-    name: github.com/ansible-network/ansible_collections.cisco.ios
-    templates:
-      - ansible-collections-cisco-ios
-      - ansible-python-jobs
-      - integrated-queue
-      - publish-to-galaxy-master-only
 
 - project:
     name: github.com/ansible-network/ansible_collections.cisco.iosxr


### PR DESCRIPTION
We have moved the repo to ansible-collections/ios.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>