### PR TITLE
Rename ansible-network/ansible_collections.cisco.iosxr

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -29,6 +29,15 @@
       - publish-to-galaxy-master-only
 
 - project:
+    name: github.com/ansible-collections/iosxr
+    templates:
+      - system-required
+      - ansible-collections-cisco-iosxr
+      - ansible-python-jobs
+      - integrated-queue
+      - publish-to-galaxy-master-only
+
+- project:
     name: github.com/ansible-collections/netcommon
     templates:
       - system-required
@@ -78,14 +87,6 @@
     name: github.com/ansible-community/pytest-molecule
     templates:
       - system-required
-
-- project:
-    name: github.com/ansible-network/ansible_collections.cisco.iosxr
-    templates:
-      - ansible-collections-cisco-iosxr
-      - ansible-python-jobs
-      - integrated-queue
-      - publish-to-galaxy-master-only
 
 - project:
     name: github.com/ansible-network/ansible_collections.cisco.nxos


### PR DESCRIPTION
This now lives under ansible-collections/iosxr.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>