### PR TITLE
Rename ansible-network/ansible_collections.junipernetworks.junos

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -38,6 +38,15 @@
       - publish-to-galaxy-master-only
 
 - project:
+    name: github.com/ansible-collections/junos
+    templates:
+      - system-required
+      - ansible-collections-juniper-junos
+      - ansible-python-jobs
+      - integrated-queue
+      - publish-to-galaxy-master-only
+
+- project:
     name: github.com/ansible-collections/netcommon
     templates:
       - system-required
@@ -95,14 +104,6 @@
     name: github.com/ansible-community/pytest-molecule
     templates:
       - system-required
-
-- project:
-    name: github.com/ansible-network/ansible_collections.junipernetworks.junos
-    templates:
-      - ansible-collections-juniper-junos
-      - ansible-python-jobs
-      - integrated-queue
-      - publish-to-galaxy-master-only
 
 - project:
     name: github.com/ansible-network/ansible_collections.vyos.vyos


### PR DESCRIPTION
The new location is ansible-collections/junos.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>