### PR TITLE
Remove ansible-collection-migration/ansible-minimal

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,10 +7,6 @@
       - system-required
 
 - project:
-    name: github.com/ansible-collection-migration/ansible-minimal
-    default-branch: devel
-
-- project:
     name: github.com/ansible-collections/eos
     templates:
       - system-required

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -96,7 +96,6 @@
           - include: []
             projects:
               - ansible/ansible
-              - ansible-collection-migration/ansible-minimal
               - ansible-community/collection_migration
               - ansible/awx
               - ansible/galaxy


### PR DESCRIPTION
This is no longer needed.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>