### PR TITLE
Add ansible-collection-migration/ansible-base to zuul

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -87,6 +87,7 @@
           - include: []
             projects:
               - ansible/ansible
+              - ansible-collection-migration/ansible-base
               - ansible-community/collection_migration
               - ansible/awx
               - ansible/galaxy


### PR DESCRIPTION
This will be online for a few more weeks, and allow us to stop building
the ansible-base tarball ourself.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>