### PR TITLE
Update network collections to use publish-to-galaxy

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -17,7 +17,7 @@
       - ansible-collections-arista-eos
       - ansible-python-jobs
       - integrated-queue
-      - publish-to-galaxy-master-only
+      - publish-to-galaxy
 
 - project:
     name: github.com/ansible-collections/ios
@@ -26,7 +26,7 @@
       - ansible-collections-cisco-ios
       - ansible-python-jobs
       - integrated-queue
-      - publish-to-galaxy-master-only
+      - publish-to-galaxy
 
 - project:
     name: github.com/ansible-collections/iosxr
@@ -35,7 +35,7 @@
       - ansible-collections-cisco-iosxr
       - ansible-python-jobs
       - integrated-queue
-      - publish-to-galaxy-master-only
+      - publish-to-galaxy
 
 - project:
     name: github.com/ansible-collections/junos
@@ -44,7 +44,7 @@
       - ansible-collections-juniper-junos
       - ansible-python-jobs
       - integrated-queue
-      - publish-to-galaxy-master-only
+      - publish-to-galaxy
 
 - project:
     name: github.com/ansible-collections/netcommon
@@ -54,7 +54,7 @@
       - ansible-collections-juniper-junos-netconf
       - ansible-python-jobs
       - integrated-queue
-      - publish-to-galaxy-master-only
+      - publish-to-galaxy
 
 - project:
     name: github.com/ansible-collections/nxos
@@ -62,7 +62,7 @@
       - system-required
       - ansible-python-jobs
       - integrated-queue
-      - publish-to-galaxy-master-only
+      - publish-to-galaxy
 
 - project:
     name: github.com/ansible-collections/vyos
@@ -71,7 +71,7 @@
       - ansible-collections-vyos-vyos
       - ansible-python-jobs
       - integrated-queue
-      - publish-to-galaxy-master-only
+      - publish-to-galaxy
 
 - project:
     name: github.com/ansible-community/ansible-bender


### PR DESCRIPTION
This is because the master only publish job is broken.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>