### PR TITLE
remove ansible-network/ansible_collections.community.vmware

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -77,8 +77,6 @@
   description: Enables pytest to discover molecule scenarios and run them
 - project: ansible-network/ansible-zuul-jobs
   description: Defines test jobs and roles
-- project: ansible-network/ansible_collections.community.vmware
-  description: Ansible Collection for VMWare
 - project: ansible-network/backup_config
   description: Ansible role for backup of running configurations from network devices
 - project: ansible-network/cisco_ios

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -46,7 +46,6 @@
           - ansible-community/molecule-vagrant
           - ansible-community/pytest-molecule
           - ansible/network
-          - ansible-network/ansible_collections.community.vmware
           - ansible-network/arista_eos
           - ansible-network/aws
           - ansible-network/azure


### PR DESCRIPTION
We don't need the repository in Zuul anymore.