### PR TITLE
Add ansible-collections/openvswitch repo to zuul

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -39,6 +39,8 @@
   description: Ansible Network Collection for Common Code
 - project: ansible-collections/nxos
   description: Ansible Network Collection for Cisco NXOS
+- project: ansible-collections/openvswitch
+  description: Ansible Network Collection for Open vSwitch
 - project: ansible-collections/vmware
   description: Ansible Collection for VMWare
 - project: ansible-collections/vmware_rest

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -27,6 +27,7 @@
           - ansible-collections/junos
           - ansible-collections/netcommon
           - ansible-collections/nxos
+          - ansible-collections/openvswitch
           - ansible-collections/vmware
           - ansible-collections/vmware_rest
           - ansible-collections/vyos


### PR DESCRIPTION
We'll be using this for the openvswitch collection for ansible-network.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>