### PR TITLE
Enable checks API for check pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -18,16 +18,19 @@
           comment: (?i)^\s*recheck\s*$
     start:
       github.com:
+        check: in_progress
         status: 'pending'
         status-url: 'https://dashboard.zuul.ansible.com/t/ansible/status/change/{change.number},{change.patchset}'
         comment: false
     success:
       github.com:
+        check: success
         status: 'success'
         status-url: 'https://dashboard.zuul.ansible.com/t/ansible/buildset/{buildset.uuid}'
       mysql:
     failure:
       github.com:
+        check: failure
         status: 'failure'
         status-url: 'https://dashboard.zuul.ansible.com/t/ansible/buildset/{buildset.uuid}'
       mysql:


### PR DESCRIPTION
Now that zuul 3.17.0 support basic checks API for github, enable so we
can test.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>