### PR TITLE
No longer report comments or status on check pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -19,20 +19,16 @@
     start:
       github.com:
         check: in_progress
-        status: 'pending'
-        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/status/change/{change.number},{change.patchset}'
         comment: false
     success:
       github.com:
         check: success
-        status: 'success'
-        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/buildset/{buildset.uuid}'
+        comment: false
       mysql:
     failure:
       github.com:
         check: failure
-        status: 'failure'
-        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/buildset/{buildset.uuid}'
+        comment: false
       mysql:
 
 - pipeline:


### PR DESCRIPTION
With checks API support enable, we should no longer need to do this. As
the data is reported to checks API tab.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>