### PR TITLE
Use checks API for gate pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -19,16 +19,20 @@
     start:
       github.com:
         check: in_progress
+        status: 'pending'
+        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/status/change/{change.number},{change.patchset}'
         comment: false
     success:
       github.com:
         check: success
-        comment: false
+        status: 'success'
+        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/buildset/{buildset.uuid}'
       mysql:
     failure:
       github.com:
         check: failure
-        comment: false
+        status: 'failure'
+        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/buildset/{buildset.uuid}'
       mysql:
 
 - pipeline:


### PR DESCRIPTION
Now that we know it is working for check pipeline, we can make the
change to gate.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>