### PR TITLE
Remove comments from check pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -19,20 +19,19 @@
     start:
       github.com:
         check: in_progress
-        status: 'pending'
-        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/status/change/{change.number},{change.patchset}'
         comment: false
+        status: 'pending'
     success:
       github.com:
         check: success
+        comment: false
         status: 'success'
-        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/buildset/{buildset.uuid}'
       mysql:
     failure:
       github.com:
         check: failure
+        comment: false
         status: 'failure'
-        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/buildset/{buildset.uuid}'
       mysql:
 
 - pipeline:


### PR DESCRIPTION
This is the 2nd try to remove comments from PRs in check. We still need
to set the status I believe, as we cannot require a check API yet.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>