### PR TITLE
Use checks API for gate pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -64,19 +64,18 @@
             - gate
     start:
       github.com:
-        status: 'pending'
-        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/status/change/{change.number},{change.patchset}'
+        check: in_progress
         comment: false
     success:
       github.com:
-        status: 'success'
-        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/buildset/{buildset.uuid}'
+        check: success
+        comment: false
         merge: true
       mysql:
     failure:
       github.com:
-        status: 'failure'
-        status-url: 'https://dashboard.zuul.ansible.com/t/ansible/buildset/{buildset.uuid}'
+        check: failure
+        comment: false
       mysql:
     window-floor: 20
     window-increase-factor: 2


### PR DESCRIPTION
Now that we know check works properly, we can also enable it on gate.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>