### PR TITLE
Remove ansible-tox-jobs from ansible-collections/vyos

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -119,7 +119,6 @@
     templates:
       - system-required
       - ansible-collections-vyos-vyos
-      - ansible-python-jobs
       - integrated-queue
       - publish-to-galaxy
 


### PR DESCRIPTION
This is because ansible/ansible devel is now frozen, so we cannot fix
issues there.  We need to allow the sync to happen, then fix the PR.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>