### PR TITLE
Add back status info for gate

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -66,16 +66,19 @@
       github.com:
         check: in_progress
         comment: false
+        status: 'pending'
     success:
       github.com:
         check: success
         comment: false
         merge: true
+        status: 'success'
       mysql:
     failure:
       github.com:
         check: failure
         comment: false
+        status: 'failure'
       mysql:
     window-floor: 20
     window-increase-factor: 2


### PR DESCRIPTION
This is because, we still need this info for branch protections.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>