### PR TITLE
Add ansible-lint to zuul for 3pci

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -93,6 +93,7 @@
           - include: []
             projects:
               - ansible/ansible
+              - ansible/ansible-lint
               - ansible-collection-migration/ansible-base
               - ansible-community/collection_migration
               - ansible/awx


### PR DESCRIPTION
We do not plan to gate ansible-lint right now, so for now allow us to
run check jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>