### PR TITLE
vmware: use squash-merge strategy

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -111,12 +111,14 @@
     templates:
       - system-required
       - ansible-collections-community-vmware
+    merge-mode: squash-merge
 
 - project:
     name: github.com/ansible-collections/vmware_rest
     templates:
       - system-required
       - ansible-python-jobs
+    merge-mode: squash-merge
 
 - project:
     name: github.com/ansible-collections/vyos


### PR DESCRIPTION
Use `squash-merge` merge strategy for the following projects:

- vmware
- vmware_rest