### PR TITLE
Allow squash merging for projects

### DIFF
--- a/tools/manage-projects.py
+++ b/tools/manage-projects.py
@@ -67,7 +67,7 @@ class Client(object):
         kwargs = {
             'allow_merge_commit': True,
             'allow_rebase_merge': False,
-            'allow_squash_merge': False,
+            'allow_squash_merge': True,
             'description': item.get('description', None),
         }
         options = item.get('options', [])


### PR DESCRIPTION
By default, now allow both merge commits and squash merging, as zuul now
supports both.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>