### PR TITLE
add publish-to-galaxy tpl to vmware projects

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -111,6 +111,7 @@
     templates:
       - system-required
       - ansible-collections-community-vmware
+      - publish-to-galaxy
     merge-mode: squash-merge
 
 - project:
@@ -118,6 +119,7 @@
     templates:
       - system-required
       - ansible-python-jobs
+      - publish-to-galaxy
     merge-mode: squash-merge
 
 - project:


### PR DESCRIPTION
Add `publish-to-galaxy` templare to `vmware` and `vmware_rest` projects.