### PR TITLE
Clean ansible-lint jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -475,33 +475,39 @@
 
 - project:
     name: github.com/ansible/ansible-lint
+    # jobs listed in project-config and defined in ansible-zuul-jobs because
+    # the project is not gated by zuul (check/gate) as jobs cannot come from
+    # unsafe repositories. Once we switch ansible-lint to be gated by zuul,
+    # these can be moved to ansible-lint project itself, making their
+    # maintenance much easier.
     third-party-check:
       jobs:
-        - tox-docs
-        - tox-linters:
-            vars:
-              tox_envlist: lint
-        - tox-py27:
-            vars:
-              tox_envlist: py27-ansible29
-        - ansible-tox-py27:
-            vars:
-              tox_envlist: py27-ansible28
-        - tox-py35:
-            vars:
-              tox_envlist: py35-ansible29
-        - tox-py36:
-            vars:
-              tox_envlist: py36-ansible29
-        - tox-py37:
-            vars:
-              tox_envlist: py37-ansible29
-        - ansible-tox-py37:
-            vars:
-              tox_envlist: py37-ansible28
-        - tox-py38:
-            vars:
-              tox_envlist: py38-ansible29
+        - ansible-lint-tox-docs
+        - ansible-lint-tox-linters
+        - ansible-lint-tox-packaging
+        - ansible-lint-tox-py35-ansible28
+        - ansible-lint-tox-py35-ansible29
+        - ansible-lint-tox-py35-ansibledevel
+        - ansible-lint-tox-py38-ansible28
+        - ansible-lint-tox-py38-ansible29
+        - ansible-lint-tox-py38-ansibledevel
+        # 2nd stage:
+        - ansible-lint-tox-py36-ansible28: &stage2
+            dependencies:
+              - ansible-lint-tox-docs
+              - ansible-lint-tox-linters
+              - ansible-lint-tox-packaging
+              - ansible-lint-tox-py35-ansible28
+              - ansible-lint-tox-py35-ansible29
+              - ansible-lint-tox-py35-ansibledevel
+              - ansible-lint-tox-py38-ansible28
+              - ansible-lint-tox-py38-ansible29
+              - ansible-lint-tox-py38-ansibledevel
+        - ansible-lint-tox-py36-ansible29: *stage2
+        - ansible-lint-tox-py36-ansibledevel: *stage2
+        - ansible-lint-tox-py37-ansible28: *stage2
+        - ansible-lint-tox-py37-ansible29: *stage2
+        - ansible-lint-tox-py37-ansibledevel: *stage2
 
 - project:
     name: github.com/ansible/ansible-runner


### PR DESCRIPTION
This should make use of jobs with standard names defined in dependent change and remove the broken tox-py27 jobs which was running alongside ansible-tox-py27 one.

Before this change the list of executed jobs was ready confusing for the use due to their inconsistent names.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/398