### PR TITLE
Begin rename of ansible-collections/asa

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -25,10 +25,10 @@
 ---
 - project: ansible-collections/amazon
   description: Ansible Collection for Amazon AWS
-- project: ansible-collections/asa
-  description: Ansible Security Collection for Cisco ASA
 - project: ansible-collections/checkpoint
   description: Ansible Security Collection for Check Point devices
+- project: ansible-collections/cisco.asa
+  description: Ansible Security Collection for Cisco ASA
 - project: ansible-collections/eos
   description: Ansible Network Collection for Arista EOS
 - project: ansible-collections/frr

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -10,14 +10,14 @@
     name: github.com/ansible-collection-migration/ansible-base
     default-branch: devel
 
-- project:
-    name: github.com/ansible-collections/asa
-    templates:
-      - system-required
-      - ansible-collections-cisco-asa
-      - ansible-python-jobs
-      - integrated-queue
-      - publish-to-galaxy
+# - project:
+#     name: github.com/ansible-collections/asa
+#     templates:
+#       - system-required
+#       - ansible-collections-cisco-asa
+#       - ansible-python-jobs
+#       - integrated-queue
+#       - publish-to-galaxy
 
 - project:
     name: github.com/ansible-collections/checkpoint

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -20,8 +20,8 @@
           # merge conflicts
           - ansible/ansible-runner
           - ansible-collections/amazon
-          - ansible-collections/asa
           - ansible-collections/checkpoint
+          - ansible-collections/cisco.asa
           - ansible-collections/eos
           - ansible-collections/frr
           - ansible-collections/ios


### PR DESCRIPTION
This will require a few commits to rename the asa repo to cisco.asa.
For now, we disable all jobs and remove it from zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>