### PR TITLE
Begin rename of ansible-collections/netcommon

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -25,6 +25,8 @@
 ---
 - project: ansible-collections/amazon
   description: Ansible Collection for Amazon AWS
+- project: ansible-collections/ansible.netcommon
+  description: Ansible Network Collection for Common Code
 - project: ansible-collections/checkpoint
   description: Ansible Security Collection for Check Point devices
 - project: ansible-collections/cisco.asa
@@ -39,8 +41,6 @@
   description: Ansible Network Collection for Cisco IOSXR
 - project: ansible-collections/junos
   description: Ansible Network Collection for Juniper JunOS
-- project: ansible-collections/netcommon
-  description: Ansible Network Collection for Common Code
 - project: ansible-collections/nxos
   description: Ansible Network Collection for Cisco NXOS
 - project: ansible-collections/openvswitch

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -71,15 +71,15 @@
       - integrated-queue
       - publish-to-galaxy
 
-- project:
-    name: github.com/ansible-collections/netcommon
-    templates:
-      - system-required
-      - ansible-collections-cisco-iosxr-netconf
-      - ansible-collections-juniper-junos-netconf
-      - ansible-python-jobs
-      - integrated-queue
-      - publish-to-galaxy
+# - project:
+#     name: github.com/ansible-collections/netcommon
+#     templates:
+#       - system-required
+#       - ansible-collections-cisco-iosxr-netconf
+#       - ansible-collections-juniper-junos-netconf
+#       - ansible-python-jobs
+#       - integrated-queue
+#       - publish-to-galaxy
 
 - project:
     name: github.com/ansible-collections/nxos

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -20,6 +20,7 @@
           # merge conflicts
           - ansible/ansible-runner
           - ansible-collections/amazon
+          - ansible-collections/ansible.netcommon
           - ansible-collections/checkpoint
           - ansible-collections/cisco.asa
           - ansible-collections/eos
@@ -27,7 +28,6 @@
           - ansible-collections/ios
           - ansible-collections/iosxr
           - ansible-collections/junos
-          - ansible-collections/netcommon
           - ansible-collections/nxos
           - ansible-collections/openvswitch
           - ansible-collections/skydive


### PR DESCRIPTION
The new location of the repo will be
ansible-collections/ansible.netcommon.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>