### PR TITLE
Update for amazon.aws and ibm.qradar collections

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -23,7 +23,7 @@
 #     - has-wiki
 #
 ---
-- project: ansible-collections/amazon
+- project: ansible-collections/amazon.aws
   description: Ansible Collection for Amazon AWS
 - project: ansible-collections/ansible.netcommon
   description: Ansible Network Collection for Common Code
@@ -35,6 +35,8 @@
   description: Ansible Security Collection for Cisco ASA
 - project: ansible-collections/frr
   description: Ansible Collection for Free Range Routing (FRR)
+- project: ansible-collections/ibm.qradar
+  description: IBM QRadar Ansible Collection
 - project: ansible-collections/ios
   description: Ansible Network Collection for Cisco IOS
 - project: ansible-collections/iosxr
@@ -122,8 +124,6 @@
   description: Ansible Yang Role
 - project: ansible-network/zuul-config
   description: Repo containing Zuul project configuration
-- project: ansible-security/ansible_collections.ibm.qradar
-  description: IBM QRadar Ansible Collection
 - project: ansible-security/ids_config
   description: Ansible role to provide configuration Intrusion Detection Systems
 - project: ansible-security/ids_install

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -443,11 +443,11 @@
         - ansible-tox-linters
         - ansible-tox-py27
 
-- project:
-    name: github.com/ansible-security/ansible_collections.ibm.qradar
-    templates:
-      - noop-jobs
-      - publish-to-galaxy
+# - project:
+#     name: github.com/ansible-security/ansible_collections.ibm.qradar
+#     templates:
+#       - noop-jobs
+#       - publish-to-galaxy
 
 - project:
     name: github.com/ansible-security/ids_config

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -19,12 +19,13 @@
           # After this point, sorting projects alphabetically will help
           # merge conflicts
           - ansible/ansible-runner
-          - ansible-collections/amazon
+          - ansible-collections/amazon.aws
           - ansible-collections/ansible.netcommon
           - ansible-collections/arista.eos
           - ansible-collections/checkpoint
           - ansible-collections/cisco.asa
           - ansible-collections/frr
+          - ansible-collections/ibm.qradar
           - ansible-collections/ios
           - ansible-collections/iosxr
           - ansible-collections/junos
@@ -82,7 +83,6 @@
           - ansible-network/vyos
           - ansible-network/windmill-config
           - ansible-network/yang
-          - ansible-security/ansible_collections.ibm.qradar
           - ansible-security/ids_config
           - ansible-security/ids_install
           - project-receptor/receptor


### PR DESCRIPTION
These recently moved until ansible-collections namespace, so we need to
update zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>