### PR TITLE
Enable ansible-collections/vyos.vyos jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -128,14 +128,14 @@
       - publish-to-galaxy
     merge-mode: squash-merge
 
-# - project:
-#     name: github.com/ansible-collections/vyos
-#     templates:
-#       - system-required
-#       - ansible-collections-vyos-vyos
-#       - ansible-python-jobs
-#       - integrated-queue
-#       - publish-to-galaxy
+- project:
+    name: github.com/ansible-collections/vyos.vyos
+    templates:
+      - system-required
+      - ansible-collections-vyos-vyos
+      - ansible-python-jobs
+      - integrated-queue
+      - publish-to-galaxy
 
 - project:
     name: github.com/ansible-community/ansible-bender


### PR DESCRIPTION
This brings back online testing for the vyos.vyos collection.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>