### PR TITLE
Rename ansible-collections/ios

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -33,12 +33,12 @@
   description: Ansible Security Collection for Check Point devices
 - project: ansible-collections/cisco.asa
   description: Ansible Security Collection for Cisco ASA
+- project: ansible-collections/cisco.ios
+  description: Ansible Network Collection for Cisco IOS
 - project: ansible-collections/frr
   description: Ansible Collection for Free Range Routing (FRR)
 - project: ansible-collections/ibm.qradar
   description: IBM QRadar Ansible Collection
-- project: ansible-collections/ios
-  description: Ansible Network Collection for Cisco IOS
 - project: ansible-collections/iosxr
   description: Ansible Network Collection for Cisco IOSXR
 - project: ansible-collections/junos

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -60,14 +60,14 @@
       - system-required
       - publish-to-galaxy
 
-- project:
-    name: github.com/ansible-collections/ios
-    templates:
-      - system-required
-      - ansible-collections-cisco-ios
-      - ansible-python-jobs
-      - integrated-queue
-      - publish-to-galaxy
+# - project:
+#     name: github.com/ansible-collections/ios
+#     templates:
+#       - system-required
+#       - ansible-collections-cisco-ios
+#       - ansible-python-jobs
+#       - integrated-queue
+#       - publish-to-galaxy
 
 - project:
     name: github.com/ansible-collections/iosxr

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -24,9 +24,9 @@
           - ansible-collections/arista.eos
           - ansible-collections/checkpoint
           - ansible-collections/cisco.asa
+          - ansible-collections/cisco.ios
           - ansible-collections/frr
           - ansible-collections/ibm.qradar
-          - ansible-collections/ios
           - ansible-collections/iosxr
           - ansible-collections/junos
           - ansible-collections/nxos


### PR DESCRIPTION
This starts the process to rename to ansible-collections/cisco.ios.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>