### PR TITLE
Rename ansible-collections/junos

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -41,7 +41,7 @@
   description: IBM QRadar Ansible Collection
 - project: ansible-collections/iosxr
   description: Ansible Network Collection for Cisco IOSXR
-- project: ansible-collections/junos
+- project: ansible-collections/junipernetworks.junos
   description: Ansible Network Collection for Juniper JunOS
 - project: ansible-collections/nxos
   description: Ansible Network Collection for Cisco NXOS

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -78,14 +78,14 @@
       - integrated-queue
       - publish-to-galaxy
 
-- project:
-    name: github.com/ansible-collections/junos
-    templates:
-      - system-required
-      - ansible-collections-juniper-junos
-      - ansible-python-jobs
-      - integrated-queue
-      - publish-to-galaxy
+# - project:
+#     name: github.com/ansible-collections/junos
+#     templates:
+#       - system-required
+#       - ansible-collections-juniper-junos
+#       - ansible-python-jobs
+#       - integrated-queue
+#       - publish-to-galaxy
 
 - project:
     name: github.com/ansible-collections/nxos

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -28,7 +28,7 @@
           - ansible-collections/frr
           - ansible-collections/ibm.qradar
           - ansible-collections/iosxr
-          - ansible-collections/junos
+          - ansible-collections/junipernetworks.junos
           - ansible-collections/nxos
           - ansible-collections/openvswitch
           - ansible-collections/skydive


### PR DESCRIPTION
This starts the rename process for
ansible-collections/junipernetworks.junos.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>