### PR TITLE
introduce base-with-aws-session

### DIFF
--- a/playbooks/base-minimal-with-aws-session/pre.yaml
+++ b/playbooks/base-minimal-with-aws-session/pre.yaml
@@ -1,0 +1,24 @@
+---
+- hosts: all:!appliance
+  tasks:
+    - name: Ensure the aws folder exist in HOME
+      file:
+        path: '{{ ansible_env.HOME }}/.aws'
+        state: directory
+
+    - name: Generate a session token from the AWS Security Token Service
+      sts_session_token:
+        aws_access_key: "{{ aws_workshops_data.aws_access_key }}"
+        aws_secret_key: "{{ aws_workshops_data.aws_secret_key }}"
+        duration_seconds: 3600
+      register: session_credentials
+
+    # See: https://boto.readthedocs.io/en/latest/boto_config_tut.html
+    - name: Lay the credential file
+      copy:
+        dest: '{{ ansible_env.HOME }}/.aws/credentials'
+        content: |
+          [default]
+          aws_access_key_id = {{ session_credentials.sts_creds.access_key }}
+          aws_secret_access_key = {{ session_credentials.sts_creds.secret_key }}
+          aws_security_token = {{ session_credentials.sts_creds.session_token }}

--- a/playbooks/workshops/run.yaml
+++ b/playbooks/workshops/run.yaml
@@ -6,19 +6,6 @@
         dest: '{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/provisioner/tower_license.json'
         content: '{{ aws_workshops_data.tower_license }}'
 
-    - name: Ensure the aws folder exist in HOME
-      file:
-        path: '{{ ansible_env.HOME }}/.aws'
-        state: directory
-
-    - name: Lay the credential file
-      copy:
-        dest: '{{ ansible_env.HOME }}/.aws/credentials'
-        content: |
-          [default]
-          aws_access_key_id = {{ aws_workshops_data.aws_access_key }}
-          aws_secret_access_key = {{ aws_workshops_data.aws_secret_key }}
-
     - name: Run tox
       include_role:
         name: tox

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -177,6 +177,7 @@
     description: |
       Running workshops from https://github.com/ansible/workshops
     pre-run:
+      - playbooks/base-minimal-with-aws-session/pre.yaml
       - playbooks/workshops/pre.yaml
     run:
       - playbooks/workshops/run.yaml
@@ -185,3 +186,15 @@
         name: aws_workshops_data
     nodeset: centos-8-1vcpu
     timeout: 5400
+
+- job:
+    name: base-with-aws-session
+    parent: base-minimal
+    description: |
+      Basic-minimal job with an associated AWS/STS session
+    pre-run:
+      - playbooks/base-minimal-with-aws-session/pre.yaml
+    secrets:
+      - secret: aws_workshops_secrets
+        name: aws_workshops_data
+    nodeset: centos-8-1vcpu


### PR DESCRIPTION
This new base job generates a temporary STS token and write it in `~/.aws/credentials` file. This way, untrusted jobs can inherite from this job and do AWS operation.