### PR TITLE
Add periodic-weekly pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -217,6 +217,22 @@
       mysql:
 
 - pipeline:
+    name: periodic-weekly
+    post-review: true
+    description: Jobs in this queue are triggered on a weekly timer.
+    manager: independent
+    precedence: low
+    trigger:
+      timer:
+        # Saturday 8am UTC is a better time to start weekend jobs, as Sunday
+        # is a working day in some geographies.
+        - time: '0 8 * * 6'
+    success:
+      mysql:
+    failure:
+      mysql:
+
+- pipeline:
     name: experimental
     description: On-demand pipeline for requesting a run against a set of jobs that are not yet gating. Leave review comment of "check experimental" to run jobs in this pipeline.
     success-message: Build succeeded (experimental pipeline).


### PR DESCRIPTION
Adds a periodic-weekly which is identical with the one used by openstack zuul tenant.

This can be used by projects that want to rebuild their jobs in order
to discover regressions from external sources.

This covers a gap as current two recurring pipelines run too often, which would put serious resource strains.