### PR TITLE
add ansible-collections-security-ibm-qradar to qradar

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -92,6 +92,7 @@
     templates:
       - system-required
       - publish-to-galaxy
+      - ansible-collections-security-ibm-qradar
 
 - project:
     name: github.com/ansible-collections/junipernetworks.junos


### PR DESCRIPTION
Apply the `ansible-collections-security-ibm-qradar` on the qradar project.