### PR TITLE
rename splunk.enterprise_security ⭢ splunk.es

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -49,7 +49,7 @@
   description: Ansible Network Collection for Open vSwitch
 - project: ansible-collections/skydive
   description: Ansible Collection for Skydive network / protocols analyzer
-- project: ansible-collections/splunk.enterprise_security
+- project: ansible-collections/splunk.es
   description: Ansible Collection for Splunk Enterprise
 - project: ansible-collections/vmware
   description: Ansible Collection for VMWare

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -32,7 +32,7 @@
           - ansible-collections/junipernetworks.junos
           - ansible-collections/openvswitch.openvswitch
           - ansible-collections/skydive
-          - ansible-collections/splunk.enterprise_security
+          - ansible-collections/splunk.es
           - ansible-collections/vmware
           - ansible-collections/vmware_rest
           - ansible-collections/vyos.vyos


### PR DESCRIPTION
This is actually the new name of the collection.