### PR TITLE
Remove ansible-collection-migration/ansible-base

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,10 +7,6 @@
       - system-required
 
 - project:
-    name: github.com/ansible-collection-migration/ansible-base
-    default-branch: devel
-
-- project:
     name: github.com/ansible-collections/ansible.netcommon
     templates:
       - system-required

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -95,7 +95,6 @@
             projects:
               - ansible/ansible
               - ansible/ansible-lint
-              - ansible-collection-migration/ansible-base
               - ansible-community/collection_migration
               - ansible/awx
               - ansible/galaxy


### PR DESCRIPTION
This is no longer needed.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>