### PR TITLE
Enable Galaxy publish for c.general

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -76,6 +76,12 @@
       - publish-to-galaxy
 
 - project:
+    name: github.com/ansible-collections/community.general
+    templates:
+      - system-required
+      - publish-to-galaxy
+
+- project:
     name: github.com/ansible-collections/frr.frr
     templates:
       - system-required

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -77,9 +77,15 @@
 
 - project:
     name: github.com/ansible-collections/community.general
-    templates:
-      - system-required
-      - publish-to-galaxy
+    third-party-check:
+      jobs:
+        - build-ansible-collection
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy
+    release:
+      jobs:
+        - release-ansible-collection-galaxy
 
 - project:
     name: github.com/ansible-collections/frr.frr

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -27,7 +27,6 @@
           - ansible-collections/cisco.ios
           - ansible-collections/cisco.iosxr
           - ansible-collections/cisco.nxos
-          - ansible-collections/community.general
           - ansible-collections/frr.frr
           - ansible-collections/ibm.qradar
           - ansible-collections/junipernetworks.junos

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -27,6 +27,7 @@
           - ansible-collections/cisco.ios
           - ansible-collections/cisco.iosxr
           - ansible-collections/cisco.nxos
+          - ansible-collections/community.general
           - ansible-collections/frr.frr
           - ansible-collections/ibm.qradar
           - ansible-collections/junipernetworks.junos


### PR DESCRIPTION
Branch protections have been enabled for `community.general`.

I'm not exactly sure which `templates` to add. We are using Shippable for CI at the moment.

Do we need any Zuul configuration files adding to https://github.com/ansible-collections/community.general ?

Once this has been seen to work I'll add it for `community.*` in a follow-up PR