### PR TITLE
Validate collections with galaxy-importer

### DIFF
--- a/playbooks/build-ansible-collection/run.yaml
+++ b/playbooks/build-ansible-collection/run.yaml
@@ -23,3 +23,15 @@
         ansible_galaxy_output_path: "{{ ansible_user_dir }}/artifacts"
         zuul_work_dir: "{{ ansible_user_dir }}/{{ item.src_dir }}"
       with_items: "{{ zuul.projects.values() | list }}"
+
+    - name: Find tarballs in folder
+      find:
+        file_type: file
+        paths: "{{ ansible_user_dir }}/artifacts"
+        patterns: "*.tar.gz"
+      register: result
+
+    - name: Confirm collection can be imported into galaxy
+      loop: "{{ result.files }}"
+      when: "item.path.endswith('.tar.gz')"
+      shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/tools/validate-collection.sh {{ item.path }}"


### PR DESCRIPTION
This will help to confirm we can import collections into galaxy, before
uploading them.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>