### PR TITLE
splunk: enable ansible-collections-security-splunk-es

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -133,6 +133,8 @@
     name: github.com/ansible-collections/splunk.es
     templates:
       - system-required
+      - publish-to-galaxy
+      - ansible-collections-security-splunk-es
     merge-mode: squash-merge
 
 - project:


### PR DESCRIPTION
Activate the following jobs:
- publish-to-galaxy
- ansible-collections-security-splunk-es