### PR TITLE
Add some community collections

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -181,19 +181,6 @@
         - release-ansible-collection-galaxy
 
 - project:
-    name: github.com/ansible-collections/community.zabbix
-    third-party-check:
-      jobs:
-        - ansible-galaxy-importer
-        - build-ansible-collection
-    pre-release:
-      jobs:
-        - release-ansible-collection-galaxy
-    release:
-      jobs:
-        - release-ansible-collection-galaxy
-
-- project:
     name: github.com/ansible-collections/community.grafana
     third-party-check:
       jobs:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -120,6 +120,54 @@
       - publish-to-galaxy
 
 - project:
+    name: github.com/ansible-collections/community.aws
+    third-party-check:
+      jobs:
+        - build-ansible-collection
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy
+    release:
+      jobs:
+        - release-ansible-collection-galaxy
+
+- project:
+    name: github.com/ansible-collections/community.azure
+    third-party-check:
+      jobs:
+        - build-ansible-collection
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy
+    release:
+      jobs:
+        - release-ansible-collection-galaxy
+
+- project:
+    name: github.com/ansible-collections/community.cassandra
+    third-party-check:
+      jobs:
+        - build-ansible-collection
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy
+    release:
+      jobs:
+        - release-ansible-collection-galaxy
+
+- project:
+    name: github.com/ansible-collections/community.crypto
+    third-party-check:
+      jobs:
+        - build-ansible-collection
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy
+    release:
+      jobs:
+        - release-ansible-collection-galaxy
+
+- project:
     name: github.com/ansible-collections/community.general
     third-party-check:
       jobs:
@@ -137,6 +185,90 @@
     third-party-check:
       jobs:
         - ansible-galaxy-importer
+        - build-ansible-collection
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy
+    release:
+      jobs:
+        - release-ansible-collection-galaxy
+
+- project:
+    name: github.com/ansible-collections/community.grafana
+    third-party-check:
+      jobs:
+        - build-ansible-collection
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy
+    release:
+      jobs:
+        - release-ansible-collection-galaxy
+
+- project:
+    name: github.com/ansible-collections/community.libvirt
+    third-party-check:
+      jobs:
+        - build-ansible-collection
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy
+    release:
+      jobs:
+        - release-ansible-collection-galaxy
+
+- project:
+    name: github.com/ansible-collections/community.mongodb
+    third-party-check:
+      jobs:
+        - build-ansible-collection
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy
+    release:
+      jobs:
+        - release-ansible-collection-galaxy
+
+- project:
+    name: github.com/ansible-collections/community.network
+    third-party-check:
+      jobs:
+        - build-ansible-collection
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy
+    release:
+      jobs:
+        - release-ansible-collection-galaxy
+
+- project:
+    name: github.com/ansible-collections/community.rabbitmq
+    third-party-check:
+      jobs:
+        - build-ansible-collection
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy
+    release:
+      jobs:
+        - release-ansible-collection-galaxy
+
+- project:
+    name: github.com/ansible-collections/community.windows
+    third-party-check:
+      jobs:
+        - build-ansible-collection
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy
+    release:
+      jobs:
+        - release-ansible-collection-galaxy
+
+- project:
+    name: github.com/ansible-collections/community.zabbix
+    third-party-check:
+      jobs:
         - build-ansible-collection
     pre-release:
       jobs:

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -106,10 +106,12 @@
               - ansible-collections/community.crypto
               - ansible-collections/community.general
               - ansible-collections/community.grafana
+              - ansible-collections/community.internal_test_tools
               - ansible-collections/community.libvirt
               - ansible-collections/community.mongodb
               - ansible-collections/community.network
               - ansible-collections/community.rabbitmq
+              - ansible-collections/community.sops
               - ansible-collections/community.windows
               - ansible-collections/community.zabbix
               - ansible/awx


### PR DESCRIPTION
For the `community.` collections which are fully managed by the community, allow build on tag.
