### PR TITLE
qradar: enable functional tests

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -115,6 +115,7 @@
     templates:
       - system-required
       - publish-to-galaxy
+      - ansible-collections-security-ibm-qradar
 
 - project:
     name: github.com/ansible-collections/junipernetworks.junos


### PR DESCRIPTION
Apply the `ansible-collections-security-ibm-qradar` template to
`ibm.qradar` collection.

Template tested here: https://github.com/ansible-collections/ibm.qradar/pull/17/files#diff-15014422bc6a3e78155e7f4c71f63e72