### PR TITLE
prepare-workspace-git: ignore appliance*

### DIFF
--- a/playbooks/base-minimal-test/pre.yaml
+++ b/playbooks/base-minimal-test/pre.yaml
@@ -22,6 +22,8 @@
       include_role:
         name: start-zuul-console
 
+- hosts: all:!appliance*
+  tasks:
     - name: Run prepare-workspace-git role
       include_role:
         name: prepare-workspace-git


### PR DESCRIPTION
Do not run `prepare-workspace-git` role on any group of hosts with `appliance` prefix.

This is the first iteration, we for now focus on `base-minimal-test`. The second iteration
will actually touch `base-minimal`.