### PR TITLE
don't run prepare-workspace-git on appliances

### DIFF
--- a/playbooks/base-minimal/pre.yaml
+++ b/playbooks/base-minimal/pre.yaml
@@ -22,6 +22,8 @@
       include_role:
         name: start-zuul-console
 
+- hosts: all:!appliance*
+  tasks:
     - name: Run prepare-workspace-git role
       include_role:
         name: prepare-workspace-git


### PR DESCRIPTION
Ensure we don't run `prepare-workspace-git` on any appliance groups.

This change has been tested through
`0e1a11cce873a3a5a592f388c70ba603383b3805` and the following PR:
https://github.com/ansible/ansible-zuul-jobs/pull/489