### PR TITLE
ansible-lint: disable ansible-devel testing

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -540,12 +540,12 @@
         - ansible-lint-tox-packaging
         - ansible-lint-tox-py36-ansible28
         - ansible-lint-tox-py36-ansible29
-        - ansible-lint-tox-py36-ansibledevel
+        # - ansible-lint-tox-py36-ansibledevel
         - ansible-lint-tox-py37-ansible28
         - ansible-lint-tox-py37-ansible29
-        - ansible-lint-tox-py37-ansibledevel
+        # - ansible-lint-tox-py37-ansibledevel
         - ansible-lint-tox-py38-ansible29
-        - ansible-lint-tox-py38-ansibledevel
+        # - ansible-lint-tox-py38-ansibledevel
 - project:
     name: github.com/ansible/ansible-runner
     default-branch: devel


### PR DESCRIPTION
Due to current state of ansible-devel is better to avoid wasting
computing and human resources on testing it.

This should be reverted as soon ansible-devel own packaging issues
are sorted.