### PR TITLE
Add project-templates to aws collections

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -11,6 +11,7 @@
     merge-mode: squash-merge
     templates:
       - system-required
+      - ansible-collections-amazon-aws
       - publish-to-galaxy
       - publish-to-automation-hub
 
@@ -105,6 +106,7 @@
     merge-mode: squash-merge
     templates:
       - system-required
+      - ansible-collections-community-aws
       - publish-to-galaxy
 
 - project:


### PR DESCRIPTION
This is so we can properly set up cross-project testing, if needed.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/534
Signed-off-by: Paul Belanger <pabelanger@redhat.com>