### PR TITLE
ansible-builder: Sync job verification between pyproject and setuppy

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -573,6 +573,12 @@
       - ansible-python-jobs
       - ansible-python3-jobs
       - publish-to-pypi
+    check:
+      jobs:
+        - ansible-builder-projecttoml-and-setuppy-insync
+    gate:
+      jobs:
+        - ansible-builder-projecttoml-and-setuppy-insync
 
 - project:
     name: github.com/ansible/ansible-lint


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/560