### PR TITLE
Create semaphore for ansible automation hub

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -147,6 +147,7 @@
       - secret: ansible_automation_hub_secret
         name: ansible_galaxy_info
     nodeset: centos-8-1vcpu
+    semaphore: ansible-automation-hub
 
 - job:
     name: release-ansible-collection-galaxy

--- a/zuul.d/semaphore.yaml
+++ b/zuul.d/semaphore.yaml
@@ -1,0 +1,4 @@
+---
+- semaphore:
+    name: ansible-automation-hub
+    max: 2


### PR DESCRIPTION
Currently, AH will process collections uploads serially, in an effort to
avoid jobs waiting on AH to run ansible-test, we can rate limit jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>