### PR TITLE
Add more jobs for community.asa

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -110,6 +110,7 @@
     merge-mode: squash-merge
     templates:
       - system-required
+      - ansible-collections-community-asa
       - ansible-collections-community-asa-units
       - publish-to-galaxy
 


### PR DESCRIPTION
This is to ensure we have pre-release of ansible.netcommon installed.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/566
Signed-off-by: Paul Belanger <pabelanger@redhat.com>