### PR TITLE
ansible-runner jobs should default to py3

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -662,15 +662,17 @@
     default-branch: devel
     templates:
       - system-required
-      - ansible-python-jobs
-      - ansible-python3-jobs
+      - ansible-python-jobs   # linting-only
+      - ansible-python3-jobs  # py3 tox jobs
       - publish-to-pypi
     check:
       jobs:
-        - ansible-tox-py27
+        - ansible-tox-py27:
+            branches: '^stable/1.*'
     gate:
       jobs:
-        - ansible-tox-py27
+        - ansible-tox-py27:
+            branches: '^stable/1.*'
 
 - project:
     name: github.com/ansible/ansible-zuul-jobs


### PR DESCRIPTION
c.f.: https://github.com/ansible/ansible-runner/pull/471

- uses new project-template that
- .. conditionally runs py2 tox jobs against
- .. PRs for pre-2.0 branches (specifically, stable/1.3.x, stable/1.4.x)