### PR TITLE
ansible.posix: default branch is now main

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -30,6 +30,7 @@
 
 - project:
     name: github.com/ansible-collections/ansible.posix
+    default-branch: main
     templates:
       - system-required
       - ansible-collections-ansible-posix-units


### PR DESCRIPTION
Set `default-branch` to `main` to reflect the change.