### PR TITLE
Add support to change default-branch for github projects

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -15,6 +15,7 @@
 # Example format:
 # - project: ansible/foo
 #   archived: true
+#   default-branch: master
 #   description: This is a great project
 #   options:
 #     - has-downloads
@@ -53,6 +54,7 @@
   description: Ansible Collection for Free Range Routing (FRR)
 - project: ansible-collections/ibm.qradar
   description: IBM QRadar Ansible Collection
+  default-branch: main
 - project: ansible-collections/junipernetworks.junos
   description: Ansible Network Collection for Juniper JunOS
 - project: ansible-collections/openvswitch.openvswitch

--- a/tools/manage-projects.py
+++ b/tools/manage-projects.py
@@ -95,6 +95,10 @@ class Client(object):
                 name=repo_name, **kwargs)
             return
 
+        # TODO(pabelanger): Currently github doesn't expose a way to auto init
+        # a repo to a branch other then master.
+        kwargs['default_branch'] = item.get('default-branch', 'master')
+
         if repo.archived:
             # Repo is archived, we cannot update it.
             return
@@ -105,6 +109,8 @@ class Client(object):
             del kwargs['allow_rebase_merge']
         if kwargs['allow_squash_merge'] == repo.allow_squash_merge:
             del kwargs['allow_squash_merge']
+        if kwargs['default_branch'] == repo.default_branch:
+            del kwargs['default_branch']
         if kwargs['description'] == repo.description:
             del kwargs['description']
         if kwargs['has_downloads'] == repo.has_downloads:


### PR DESCRIPTION
This is the first step on gitops for branch rename in github. Most
projects no longer wish to use 'master' as the default branch name. As
such, we need a way to update it.

Currently, there is no way to auto_init a repo in github using a branch
other then master.  We'll have to work around this.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>