### PR TITLE
Initial support to manage branch protections

### DIFF
--- a/github/acls/ansible-network/sandbox.config
+++ b/github/acls/ansible-network/sandbox.config
@@ -1,0 +1,13 @@
+---
+# NOTE(pabelanger): See https://developer.github.com/v3/repos/branches/#parameters-1
+# for fields
+- branch:
+  name: master
+  required_status_checks:
+    contexts:
+      - ansible/check
+      - ansible/gate
+  enforce_admins: true
+  restrictions:
+    apps:
+      - ansible-zuul

--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -19,6 +19,7 @@
 #
 # Example format:
 # - project: ansible/foo
+#   acl-config: acls/ansible/bar.config
 #   archived: true
 #   default-branch: master
 #   description: This is a great project


### PR DESCRIPTION
This adds basic support to manage branch protections via git. We'll
first start testing on ansible-network/sandbox then move to other
projects.

The idea, is we drop down a .config file, if the settings we want to
enforce for each branch, on each project.  We can also include a
top-level common file, for shared projects if needed.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>