### PR TITLE
drop duplicated entry in zuul.d/projects.yaml

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -121,11 +121,6 @@
       - publish-to-galaxy-3pci
 
 - project:
-    name: github.com/ansible-collections/community.aws
-    templates:
-      - publish-to-galaxy-3pci
-
-- project:
     name: github.com/ansible-collections/community.azure
     templates:
       - publish-to-galaxy-3pci


### PR DESCRIPTION
`community.aws` is listed two times in a row.