### PR TITLE
Set tox_envlist: venv for tox role

### DIFF
--- a/playbooks/ansible-collection/run-pre.yaml
+++ b/playbooks/ansible-collection/run-pre.yaml
@@ -5,6 +5,7 @@
       include_role:
         name: tox
       vars:
+        tox_envlist: venv
         tox_extra_args: -vv --notest
         tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"

--- a/playbooks/build-ansible-collection/run.yaml
+++ b/playbooks/build-ansible-collection/run.yaml
@@ -5,6 +5,7 @@
       include_role:
         name: tox
       vars:
+        tox_envlist: venv
         tox_extra_args: -vv --notest
         tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"


### PR DESCRIPTION
This fixes the follow upstream commit:

https://opendev.org/zuul/zuul-jobs/commit/c388e61160908c001c41ae44fb51ae4be81ada45

Signed-off-by: Paul Belanger <pabelanger@redhat.com>