### PR TITLE
add generate-and-build-ansible-collection

### DIFF
--- a/playbooks/generate-ansible-collection/pre.yaml
+++ b/playbooks/generate-ansible-collection/pre.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  tasks:
+    - name: Run tox environment(s) top repare the collection
+      include_role:
+        name: tox
+      vars:
+        tox_envlist: "{{ generate_with_tox_envlist|default('refresh_modules') }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -112,6 +112,13 @@
     nodeset: centos-8-1vcpu
 
 - job:
+    name: generate-and-build-ansible-collection
+    parent: build-ansible-collection
+    description: |
+      Generate content and Build ansible collections and return artifacts to zuul
+    pre-run: playbooks/generate-ansible-collection/pre.yaml
+
+- job:
     name: release-ansible-python
     description: |
       Release python tarballs / wheels to pypi.org.


### PR DESCRIPTION
`generate-and-build-ansible-collection` is a new job based on
`build-ansible-collection`. It has the ability to use `tox` to generate
content in the collection directory, this before the collection get
build.