### PR TITLE
Add cisco.asa jobs to ansible.netcommon

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -23,6 +23,7 @@
       - system-required
       - ansible-collections-ansible-netcommon-units
       - ansible-collections-arista-eos
+      - ansible-collections-cisco-asa
       - ansible-collections-cisco-iosxr-netconf
       - ansible-collections-juniper-junos-netconf
       - ansible-collections-openvswitch-openvswitch


### PR DESCRIPTION
Add more test coverage to ansible.netcommon collection.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>