### PR TITLE
vmware_rest default branch is now main

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -91,6 +91,7 @@
   default-branch: main
 - project: ansible-collections/vmware_rest
   description: Ansible Collection for VMWare (REST modules)
+  default-branch: main
 - project: ansible-collections/vyos.vyos
   description: Ansible Network Collection for VyOS
   default-branch: main

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -301,6 +301,7 @@
 
 - project:
     name: github.com/ansible-collections/vmware_rest
+    default-branch: main
     merge-mode: squash-merge
     templates:
       - system-required


### PR DESCRIPTION
`vmware_rest` default branch is now `main`.