### PR TITLE
vmware-rest: use the new dedicated template

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -302,10 +302,9 @@
 - project:
     name: github.com/ansible-collections/vmware_rest
     default-branch: main
-    merge-mode: squash-merge
     templates:
       - system-required
-      - ansible-python-jobs
+      - ansible-collections-community-vmware-rest
       - publish-to-galaxy
 
 - project:


### PR DESCRIPTION
The template is called `ansible-collections-community-vmware-rest`.
Also, disable the `squash-merge`.