### PR TITLE
Remove cloud.common from integrated-queue

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -124,7 +124,6 @@
     templates:
       - system-required
       - ansible-python-jobs
-      - integrated-queue
       - publish-to-galaxy
 
 - project:


### PR DESCRIPTION
Today this is used by network collections, a follow up commit will
rename that to network-integrated-queue.  We can then create
cloud-integrated-queue.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>