### PR TITLE
Add ansible-changelog-fragment job

### DIFF
--- a/playbooks/ansible-changelog-fragment/run.yaml
+++ b/playbooks/ansible-changelog-fragment/run.yaml
@@ -1,0 +1,15 @@
+---
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Check for changelog fragments
+      args:
+        chdir: "{ zuul.project.src_dir }}"
+      ignore_errors: true
+      shell: git diff --name-only --exit-code changelogs/fragments
+      register: r
+
+    - name: Changelog fragment failed
+      fail:
+        msg: "Your project is missing a changelog fragment, please add one. It should explain to end users the reason for your change."
+      when: r.rc == 0

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -74,6 +74,13 @@
 
 # ansible/project-config jobs
 - job:
+    name: ansible-changelog-fragment
+    description: Ensure PRs have generated changelog fragments.
+    run: playbooks/ansible-changelog-fragment/run.yaml
+    nodeset:
+      nodes: []
+
+- job:
     name: project-config-tox-github
     parent: tox
     description: |


### PR DESCRIPTION
We'll use this job to validate ansible pull-requests have the required
changelog fragments.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>