### PR TITLE
Fix executor source path for ansible-changelog-fragment

### DIFF
--- a/playbooks/ansible-changelog-fragment/run.yaml
+++ b/playbooks/ansible-changelog-fragment/run.yaml
@@ -4,7 +4,7 @@
   tasks:
     - name: Check for changelog fragments
       args:
-        chdir: "{{ zuul.project.src_dir }}"
+        chdir: "{{ zuul.executor.src_root }}/{{ zuul.project.canonical_name }}"
       shell: git diff --name-only --exit-code changelogs/fragments
       register: r
 


### PR DESCRIPTION
This should be the correct path to source code now.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>