### PR TITLE
Rework ansible-changelog-fragment playbook

### DIFF
--- a/playbooks/ansible-changelog-fragment/run.yaml
+++ b/playbooks/ansible-changelog-fragment/run.yaml
@@ -5,10 +5,10 @@
     - name: Check for changelog fragments
       args:
         chdir: "{{ zuul.executor.src_root }}/{{ zuul.project.canonical_name }}"
-      shell: git diff --name-only --exit-code changelogs/fragments
+      shell: git show --name-status --exit-code --oneline --diff-filter=A | grep changelogs/fragments/
       register: r
 
     - name: Changelog fragment failed
       fail:
         msg: "Your project is missing a changelog fragment, please add one. It should explain to end users the reason for your change."
-      when: r.rc == 0
+      when: not r.rc


### PR DESCRIPTION
This should be a little better when checking if a new fragment has been
added.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>