### PR TITLE
Flip to job.files for ansible-changelog-fragment

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -77,11 +77,9 @@
     name: ansible-changelog-fragment
     description: Ensure PRs have generated changelog fragments.
     run: playbooks/ansible-changelog-fragment/run.yaml
-    irrelevant-files:
-      - ^changelogs/.*$
-      - ^doc/.*$
-      - galaxy.yml
-      - README.md
+    files:
+      - ^plugins/.*$
+      - ^tests/.*$
     nodeset:
       nodes: []
 


### PR DESCRIPTION
If we change plugins / tests, we always want a changelog fragment.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>