### PR TITLE
add vmware_rest_code_generator in tenants

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -40,6 +40,7 @@
           - ansible-collections/symantec.epm
           - ansible-collections/vmware
           - ansible-collections/vmware_rest
+          - ansible-collections/vmware_rest_code_generator
           - ansible-collections/vyos.vyos
           - ansible-community/ansible-bender
           - ansible-community/molecule


### PR DESCRIPTION
Add `ansible-collections/vmware_rest_code_generator` in the tenants
list.