### PR TITLE
ensure git is installed in base-minimal

### DIFF
--- a/playbooks/base-minimal/pre.yaml
+++ b/playbooks/base-minimal/pre.yaml
@@ -24,6 +24,11 @@
 
 - hosts: all:!appliance*
   tasks:
+    - name: Ensure git is installed
+      package:
+        name: git
+        state: present
+      become: true
     - name: Run prepare-workspace-git role
       include_role:
         name: prepare-workspace-git


### PR DESCRIPTION
Ensure `git` is here before we start `prepare-workspace-git`. The
command is in the default DIB image. But it's not the case for AWS.

On AWS, cloud-init is in charge of the installation of the package.
But since the SSH service starts faster than the package installation,
we can face a race condition when the package manager is running
and Zuul starts a job at the same time.