### PR TITLE
Revert "removed ansible-network.yang"

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -157,6 +157,9 @@
   default-branch: devel
 - project: ansible-network/windmill-config
   description: Ansible configuration files for windmill project
+- project: ansible-network/yang
+  description: Ansible Yang Role
+  default-branch: devel
 - project: ansible-network/zuul-config
   description: Repo containing Zuul project configuration
 - project: ansible-security/ids_config

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -80,6 +80,7 @@
           - ansible-network/sandbox
           - ansible-network/vyos
           - ansible-network/windmill-config
+          - ansible-network/yang
           - ansible-security/ids_config
           - ansible-security/ids_install
           - EducationSwing/zuul-test


### PR DESCRIPTION
This is a partial revert, so we properly retire a project github.

This reverts commit 0b99be615d0a0ffa4cc9ccf73e72427194a8a299.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>