### PR TITLE
Add noop jobs to ansible-network/yang repo

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -596,6 +596,12 @@
               - name: github.com/ansible-network/network-engine
 
 - project:
+    name: github.com/ansible-network/yang
+    default-branch: devel
+    templates:
+      - noop-jobs
+
+- project:
     name: github.com/ansible-security/ids_config
     check:
       jobs:


### PR DESCRIPTION
This is the first step in retiring a project, we remove all jobs so we
can merge code without any testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>