### PR TITLE
cloud.common: add publish-to-automation-hub

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -125,6 +125,7 @@
       - system-required
       - ansible-python-jobs
       - publish-to-galaxy
+      - publish-to-automation-hub
 
 - project:
     name: github.com/ansible-collections/community.asa


### PR DESCRIPTION
Apply the publish-to-automation-hub template to cloud.common.