### PR TITLE
Add ansible-collections/ansible.network jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -35,6 +35,13 @@
       - publish-to-automation-hub
 
 - project:
+    name: github.com/ansible-collections/ansible.network
+    default-branch: main
+    merge-mode: squash-merge
+    templates:
+      - system-required
+
+- project:
     name: github.com/ansible-collections/ansible.posix
     default-branch: main
     templates:


### PR DESCRIPTION
This adds the first jobs to ansible.network collection.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>