### PR TITLE
Revert "ansible-builder: Add ansible-tox-py36 jobs"

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -645,11 +645,9 @@
     check:
       jobs:
         - ansible-builder-projecttoml-and-setuppy-insync
-        - ansible-tox-py38
     gate:
       jobs:
         - ansible-builder-projecttoml-and-setuppy-insync
-        - ansible-tox-py38
 
 - project:
     name: github.com/ansible/ansible-runner


### PR DESCRIPTION
This reverts commit 83c286c37de7d14c6e1fb04fa05dab7f8cb995c1.