### PR TITLE
Drop templates from molecule-vagrant

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -404,8 +404,7 @@
 - project:
     name: github.com/ansible-community/molecule-vagrant
     templates:
-      - publish-to-pypi
-      - system-required
+      - noop-jobs
 
 - project:
     name: github.com/ansible-network/arista_eos


### PR DESCRIPTION
Molecule vagrant does use github workflows as primary CI and we do not need:
* github-workflows job failure
* publish-to-pypi as we can publish using github directly
