### PR TITLE
vmwware_rest_code_generator: associate template

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -371,6 +371,7 @@
     default-branch: main
     templates:
       - ansible-python3-jobs
+      - ansible-collections-community-vmware-rest
     check:
       jobs:
         - ansible-tox-linters


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/685

Associate the `ansible-collections-community-vmware-rest` template to the
`vmware.vmware_rest` repository.