### PR TITLE
vmware_rest_code_generator: use the right template

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -371,7 +371,7 @@
     default-branch: main
     templates:
       - ansible-python3-jobs
-      - ansible-collections-community-vmware-rest
+      - ansible-collections-community-vmware-rest-code-generator
     check:
       jobs:
         - ansible-tox-linters


### PR DESCRIPTION
Actually use:
`ansible-collections-community-vmware-rest-code-generator`
not:
`ansible-collections-community-vmware-rest`