### PR TITLE
Remove EducationSwing/zuul-test from zuul

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -182,8 +182,6 @@
 - project: ansible/workshops
   description: Training Course for Ansible Automation Platform
   default-branch: devel
-- project: EducationSwing/zuul-test
-  description: zuul-test repo
 - project: project-receptor/python-receptor
   description: >-
     Project Receptor is a flexible multi-service relayer with remote execution and

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -748,11 +748,6 @@
         - workshops-tox-integration-windows
 
 - project:
-    name: github.com/EducationSwing/zuul-test
-    templates:
-      - system-required
-
-- project:
     name: github.com/project-receptor/python-receptor
     default-branch: devel
     templates:

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -84,7 +84,6 @@
           - ansible-network/windmill-config
           - ansible-security/ids_config
           - ansible-security/ids_install
-          - EducationSwing/zuul-test
           - project-receptor/python-receptor
           - pycontribs/selinux
 


### PR DESCRIPTION
This github org has been deleted and was only to test github enterprise.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>