### PR TITLE
Add ansible-runner-container-image-jobs to ansible-runner

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -687,6 +687,7 @@
     default-branch: devel
     templates:
       - system-required
+      - ansible-runner-container-image-jobs
       - ansible-python-jobs   # linting-only
       - ansible-python3-jobs  # py3 tox jobs
       - publish-to-pypi


### PR DESCRIPTION
This will allow us to start building container images, with the goal of
testing them with ansible-builder.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/713
Signed-off-by: Paul Belanger <pabelanger@redhat.com>