### PR TITLE
Add ansible-buildset-registry job

### DIFF
--- a/playbooks/buildset-registry/post.yaml
+++ b/playbooks/buildset-registry/post.yaml
@@ -1,0 +1,3 @@
+---
+- hosts: all
+  tasks: []

--- a/playbooks/buildset-registry/pre.yaml
+++ b/playbooks/buildset-registry/pre.yaml
@@ -1,0 +1,29 @@
+---
+- hosts: all
+  tasks:
+    - name: Install container runtime
+      include_role:
+        name: "ensure-{{ (container_command == 'docker') | ternary('docker', 'podman') }}"
+
+    # NOTE(pabelanger): we force docker until we can figure out podman IPV6 issue
+    - name: Install docker runtime
+      when: buildset_registry is not defined
+      include_role:
+        name: ensure-docker
+
+    - name: Run buildset registry (if not already running)
+      when: buildset_registry is not defined
+      include_role:
+        name: run-buildset-registry
+      vars:
+        container_command: docker
+
+    - name: Use buildset registry
+      include_role:
+        name: use-buildset-registry
+
+- hosts: localhost
+  tasks:
+    - name: Run pull-from-intermediate-registry role
+      include_role:
+        name: pull-from-intermediate-registry

--- a/playbooks/buildset-registry/run.yaml
+++ b/playbooks/buildset-registry/run.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  tasks:
+    - name: Pause the job
+      zuul_return:
+        data:
+          zuul:
+            pause: true

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -230,6 +230,30 @@
     timeout: 5400
 
 - job:
+    name: ansible-buildset-registry
+    description: |
+      Starts a buildset registry which interacts with the intermediate
+      CI registry to share speculative container images between
+      projects.
+
+      Configure any jobs which require the use of a buildset registry
+      to depend on this job using the "dependencies" job attribute.
+
+      This job will pause after starting the registry so that it is
+      available to any jobs which depend on it.  Once all such jobs
+      are complete, this job will finish.
+    pre-run: playbooks/buildset-registry/pre.yaml
+    run: playbooks/buildset-registry/run.yaml
+    post-run: playbooks/buildset-registry/post.yaml
+    requires: container-image
+    nodeset: ubuntu-bionic-1vcpu
+    vars:
+      container_command: docker
+    secrets:
+      - secret: ansible-intermediate-registry
+        name: intermediate_registry
+
+- job:
     name: ansible-upload-container-image
     parent: ansible-build-container-image
     description: |

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -2,6 +2,24 @@
 #   tools/encrypt_secret.py --infile in.txt --outfile out.txt --tenant ansible https://dashboard.zuul.ansible.com ansible/project-config
 ---
 - secret:
+    name: ansible-intermediate-registry
+    data:
+      host: zr01.sjc1.vexxhost.zuul.ansible.com
+      port: 5000
+      username: zuul
+      password: !encrypted/pkcs1-oaep
+        - CTEYBazCY5x1bsaDD8QFJvZc3sOxkYgP2rnG9PT5Xe7SwhORUtEOn90Cr8FtGwNr8CNpN
+          75xeoot89BnU6gnVYRu8nADWxsRkzegrUkuKi5WZIgWFWuMMMpKWyUla52oKm5pF9Y36y
+          CXJTOIXKwOY2T3sCweRpy4v8oCT4muJhRxnluTX2+jrlgNZoqbxGZH4dgmozdvaU0UI6j
+          qgkph9Lzc9oa5I37+O9Rv7I9mNwUTHYhduIH1hRmah0VBUWEHl9AOfrUJUF71/G0Fngwa
+          tNLn3B7w5bhATxH/ZhGpQbWJocMJ/865kQhUU2ZZQXj2infpfkal4xgPTiaTcoGcMbZKK
+          4A/htdZauUsQPrJHrQKJnXEzdwlEnTXLH/zD0kgfWfqMbO2jW+aaobrSE68XQ9Rw5Xt4Q
+          Ri0O6mkUhs4FyjncWNIJWiBWNZAFZtC/lhVEEXERrHmHeUIkdc3EBAJ4hYAKYX0r5/Xqm
+          Ch7zYtUHWZnA1V6B74on3kdPRmyPwW91Upv6n/+A61Rx/HIPlVNtJoI56ci8eA3tTgFeV
+          Mbw2ii+tSSVm2vjZlFCHc5CBWp3ZPpEloFtW4c24GWpH1IXHrWjPpaEtcLqL1S+F2psDU
+          3dzQnoveZxGYM7xNjosfK64+PgSL/7HKNsJFOhOS1T/Aa5GU+SucnBSqxWJl/A=
+
+- secret:
     name: container_registry_credentials
     data:
       quay.io:


### PR DESCRIPTION
This move ansible-buildset-registry into config-project so we can
publish images to our zuul-registry.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>