### PR TITLE
Use zuul-registry to store images

### DIFF
--- a/playbooks/buildset-registry/post.yaml
+++ b/playbooks/buildset-registry/post.yaml
@@ -1,3 +1,6 @@
 ---
-- hosts: all
-  tasks: []
+- hosts: localhost
+  tasks:
+    - name: Run push-to-intermediate-registry role
+      include_role:
+        name: push-to-intermediate-registry


### PR DESCRIPTION
Now that we know zuul-registry is only, we can start to publish images
to it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>