### PR TITLE
Add ansible/galaxy_ng to ansible tenant

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -122,6 +122,7 @@
               - ansible-collections/hetzner.hcloud
               - ansible/awx
               - ansible/galaxy
+              - ansible/galaxy_ng
               - ansible/galaxy-importer
               - ansible/pylibssh
               - ansible/workshops


### PR DESCRIPTION
This allows us to run 3pci jobs for the project.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>