### PR TITLE
Remove project-receptor/python-receptor jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -795,15 +795,6 @@
         - workshops-tox-integration-windows
 
 - project:
-    name: github.com/project-receptor/python-receptor
-    default-branch: devel
-    templates:
-      - system-required
-      - ansible-python-jobs
-      - ansible-python3-jobs
-      - publish-to-pypi
-
-- project:
     name: github.com/pycontribs/selinux
     templates:
       - system-required


### PR DESCRIPTION
This project looks to have renamed to project-receptor/receptor and no
longer using zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>