### PR TITLE
Fix syntax issue with aws_management.config

### DIFF
--- a/github/acls/ansible-network/aws_management.config
+++ b/github/acls/ansible-network/aws_management.config
@@ -2,13 +2,12 @@
 # NOTE(pabelanger): See https://developer.github.com/v3/repos/branches/#parameters-1
 # for fields
 - branch:
-  name: main 
-  enforce_admins: true
   name: main
   required_status_checks:
     contexts:
       - ansible/check
       - ansible/gate
+  enforce_admins: true
   restrictions:
     apps:
       - ansible-zuul


### PR DESCRIPTION
Signed-off-by: Paul Belanger <pabelanger@redhat.com>