### PR TITLE
Remove project-receptor/python-receptor from zuul

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -194,9 +194,3 @@
 - project: ansible/workshops
   description: Training Course for Ansible Automation Platform
   default-branch: devel
-- project: project-receptor/python-receptor
-  description: >-
-    Project Receptor is a flexible multi-service relayer with remote execution and
-    orchestration capabilities linking controllers with executors across a mesh of
-    nodes.
-  default-branch: devel

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -87,7 +87,6 @@
           - ansible-network/windmill-config
           - ansible-security/ids_config
           - ansible-security/ids_install
-          - project-receptor/python-receptor
           - pycontribs/selinux
 
           # Don't load any configuration from these projects because we


### PR DESCRIPTION
The team has decided to create a new project, and not use zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>