### PR TITLE
Add projects to execution-environment shared queue

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -693,6 +693,7 @@
     name: github.com/ansible/ansible-builder
     default-branch: devel
     templates:
+      - execution-environments-queue
       - system-required
       - ansible-python-jobs
       - ansible-python3-jobs
@@ -709,6 +710,7 @@
     default-branch: devel
     templates:
       - system-required
+      - execution-environments-queue
       - ansible-python-jobs   # linting-only
       - ansible-python3-jobs  # py3 tox jobs
       - publish-to-pypi
@@ -793,12 +795,14 @@
     default-branch: main
     templates:
       - system-required
+      - execution-environments-queue
 
 - project:
     name: github.com/ansible/python-builder-image
     default-branch: main
     templates:
       - system-required
+      - execution-environments-queue
 
 - project:
     name: github.com/ansible/workshops


### PR DESCRIPTION
This allows us to do better cross-project testing between:

  ansible-builder
  ansible-runner
  python-builder-image
  python-base-image

All things needed to properly create an execution environment.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/735
Signed-off-by: Paul Belanger <pabelanger@redhat.com>