### PR TITLE
Remove usage of ansible-builder-projecttoml-and-setuppy-insync

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -698,12 +698,6 @@
       - ansible-python-jobs
       - ansible-python3-jobs
       - publish-to-pypi
-    check:
-      jobs:
-        - ansible-builder-projecttoml-and-setuppy-insync
-    gate:
-      jobs:
-        - ansible-builder-projecttoml-and-setuppy-insync
 
 - project:
     name: github.com/ansible/ansible-runner


### PR DESCRIPTION
We are moving to dynamic versioning with pbr