### PR TITLE
Create release-ansible-python-poetry job

### DIFF
--- a/playbooks/build-python-tarball/run.yaml
+++ b/playbooks/build-python-tarball/run.yaml
@@ -1,6 +1,25 @@
 ---
 - hosts: all
   tasks:
+    # NOTE(pabelanger): This is kinda hacky, but poetry doesn't have a good
+    # way to automate this.
+    - name: Update poetry version
+      block:
+        - name: Setup tox role
+          include_role:
+            name: tox
+          vars:
+            tox_envlist: venv
+            tox_extra_args: -vv --notest
+            tox_install_siblings: false
+            zuul_work_dir: "{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
+
+        - name: Generate version number for poetry
+          args:
+            chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+          shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/generate-poetry-version"
+      when: release_poetry_project is defined
+
     - name: Run build-python-release role
       include_role:
         name: build-python-release

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -125,17 +125,27 @@
     name: release-ansible-python
     description: |
       Release python tarballs / wheels to pypi.org.
+    protected: true
     pre-run: playbooks/build-python-tarball/pre.yaml
     run: playbooks/build-python-tarball/run.yaml
     post-run:
       - playbooks/build-python-tarball/post.yaml
       - playbooks/publish/pypi.yaml
+    required-projects:
+      - github.com/ansible-network/releases
     secrets:
       - secret: pypi_secret
         name: pypi_info
     vars:
       release_python: python3
     nodeset: centos-8-1vcpu
+
+- job:
+    name: release-ansible-python-poetry
+    parent: release-ansible-python
+    final: true
+    vars:
+      release_poetry_project: true
 
 - job:
     name: release-ansible-collection-automation-hub


### PR DESCRIPTION
Some project use poetry, this is our first step to help automate their
releases for git tags.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>