### PR TITLE
Switch ansible/ansible-builder to use poetry release job

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -697,7 +697,7 @@
       - system-required
       - ansible-python-jobs
       - ansible-python3-jobs
-      - publish-to-pypi
+      - publish-to-pypi-poetry
 
 - project:
     name: github.com/ansible/ansible-runner


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/738
Signed-off-by: Paul Belanger <pabelanger@redhat.com>