### PR TITLE
Revert "Switch ansible/ansible-builder to use poetry release job"

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -697,7 +697,7 @@
       - system-required
       - ansible-python-jobs
       - ansible-python3-jobs
-      - publish-to-pypi-poetry
+      - publish-to-pypi
 
 - project:
     name: github.com/ansible/ansible-runner


### PR DESCRIPTION
This reverts commit c1ee4da3286edd320889ef5d0e4b6368a900a252.