### PR TITLE
Add post jobs to ansible/ansible

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -688,6 +688,12 @@
     default-branch: devel
     templates:
       - ansible-test-network-integration
+    post:
+      jobs:
+        - ansible-core-upload-container-image:
+            branches: devel
+            vars:
+              upload_container_image_promote: false
 
 - project:
     name: github.com/ansible/ansible-builder


### PR DESCRIPTION
When ansible/ansible merges code to devel, build / publish our
ansible-core container image.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>