### PR TITLE
tenants: add ansible/cloud-ee

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -54,6 +54,7 @@
           - ansible-community/molecule
           - ansible-community/molecule-libvirt
           - ansible-community/molecule-vagrant
+          - ansible/cloud-ee
           - ansible/network
           - ansible/network-ee
           - ansible-network/arista_eos


### PR DESCRIPTION
Add the https://github.com/ansible/cloud-ee repository.

See: https://github.com/ansible/project-config/pull/705