### PR TITLE
Add network-ee jobs to arista.eos collection

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -72,6 +72,8 @@
       - ansible-collections-arista-eos
       - ansible-collections-arista-eos-units
       - ansible-python-jobs
+      - network-ee-container-image-jobs
+      - network-ee-tests
       - integrated-queue
       - publish-to-galaxy
       - publish-to-automation-hub


### PR DESCRIPTION
Now is the time to start moving to network-ee for all our testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>