### PR TITLE
Add ansible-runner-build-container-image-stable-2.9 to ansible/ansible

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -695,6 +695,10 @@
     default-branch: devel
     templates:
       - ansible-test-network-integration
+    third-party-check-silent:
+      jobs:
+        - ansible-runner-build-container-image-stable-2.9:
+            branches: stable-2.9
     post:
       jobs:
         - ansible-core-upload-container-image:


### PR DESCRIPTION
This allows us to properly test ansible/ansible changes for EEs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>