### PR TITLE
Add ansible-runner container build job for ansible/ansible

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -705,6 +705,10 @@
             branches: devel
             vars:
               upload_container_image_promote: false
+        - ansible-runner-upload-container-image-stable-2.9:
+            branches: stable-2.9
+            vars:
+              upload_container_image_promote: false
 
 - project:
     name: github.com/ansible/ansible-builder


### PR DESCRIPTION
When we merge stable-2.9 changes to ansible/ansible, also rebuild
ansible-runner.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>