### PR TITLE
Allow jobs to toggle pulling from intermediate registry

### DIFF
--- a/playbooks/buildset-registry/pre.yaml
+++ b/playbooks/buildset-registry/pre.yaml
@@ -27,3 +27,4 @@
     - name: Run pull-from-intermediate-registry role
       include_role:
         name: pull-from-intermediate-registry
+      when: use_intermediate_registry | default(True)


### PR DESCRIPTION
It is possible, that some jobs do not want to pull from the intermediate
registry, and only consume images from the buildset registry.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>