### PR TITLE
Remove vexxhost for uploading logs

### DIFF
--- a/playbooks/base-minimal-test/post-logs.yaml
+++ b/playbooks/base-minimal-test/post-logs.yaml
@@ -20,30 +20,16 @@
       vars:
         zuul_log_path_shard_build: true
 
-    - name: Upload logs to swift
-      block:
-        - name: Run upload-logs-swift role
-          no_log: true
-          include_role:
-            name: upload-logs-swift
-          vars:
-            zuul_log_partition: true
-            zuul_log_container: ansible
-            zuul_log_cloud_config: "{{ vexxhost_clouds_yaml }}"
-            zuul_log_delete_after: 7776000
-      rescue:
-        # NOTE(pabelanger): If for some reason we cannot upload logs, try
-        # again. This time we'll upload to rackspace.
-        - name: Run upload-logs-swift role
-          no_log: true
-          include_role:
-            name: upload-logs-swift
-          vars:
-            zuul_log_partition: true
-            zuul_log_container: ansible
-            zuul_log_cloud_config: "{{ item }}"
-            zuul_log_delete_after: 7776000
-          with_random_choice:
-            - "{{ rackspace_dfw_clouds_yaml }}"
-            - "{{ rackspace_iad_clouds_yaml }}"
-            - "{{ rackspace_ord_clouds_yaml }}"
+    - name: Run upload-logs-swift role
+      no_log: true
+      include_role:
+        name: upload-logs-swift
+      vars:
+        zuul_log_partition: true
+        zuul_log_container: ansible
+        zuul_log_cloud_config: "{{ item }}"
+        zuul_log_delete_after: 7776000
+      with_random_choice:
+        - "{{ rackspace_dfw_clouds_yaml }}"
+        - "{{ rackspace_iad_clouds_yaml }}"
+        - "{{ rackspace_ord_clouds_yaml }}"


### PR DESCRIPTION
They currently are updating their infra, and rather then hitting the
service (and failing) we can remove them for now.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>