### PR TITLE
Add new repo for servicenow.itsm

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -96,6 +96,9 @@
 - project: ansible-collections/openvswitch.openvswitch
   description: Ansible Network Collection for Open vSwitch
   default-branch: main
+- project: ansible-collections/servicenow.itsm
+  description: Ansible Collection for ServiceNow ITSM
+  default-branch: main
 - project: ansible-collections/skydive
   description: Ansible Collection for Skydive network / protocols analyzer
 - project: ansible-collections/splunk.es


### PR DESCRIPTION
This collection should only have a repo for now - it's still being developed by XLab and we don't want any Zuul checks/publishing until a later date.