### PR TITLE
ansible-core-ci: write the session fil in work_root

### DIFF
--- a/playbooks/ansible-core-ci/pre.yaml
+++ b/playbooks/ansible-core-ci/pre.yaml
@@ -3,6 +3,7 @@
   vars:
     create_core_ci_stage: dev
     create_core_ci_session_key: "{{ ansible_core_ci.key }}"
+    create_core_ci_local_target_file: "{{ zuul.executor.work_root }}/aws_session.json"
   tasks:
     - name: Prepare the aws/sts session
       include_role:


### PR DESCRIPTION
There is some restriction in place that revent the use of the /tmp
directory.