### PR TITLE
Revert "ansible-core-ci: write the session fil in work_root"

### DIFF
--- a/playbooks/ansible-core-ci/pre.yaml
+++ b/playbooks/ansible-core-ci/pre.yaml
@@ -3,7 +3,6 @@
   vars:
     create_core_ci_stage: dev
     create_core_ci_session_key: "{{ ansible_core_ci.key }}"
-    create_core_ci_local_target_file: "{{ zuul.executor.work_root }}/aws_session.json"
   tasks:
     - name: Prepare the aws/sts session
       include_role:


### PR DESCRIPTION
Reverting because the file was actually generated on the controller
node. However, the template was generated from the executor. This was
actually the root cause of the problem.

This reverts commit a522f2d3d970b974046403e289b50274b74dfaa0.