### PR TITLE
Add ara projects to Zuul config

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -52,6 +52,9 @@
           - ansible-collections/vmware_rest_code_generator
           - ansible-collections/vyos.vyos
           - ansible-community/ansible-bender
+          - ansible-community/ara
+          - ansible-community/ara-collection
+          - ansible-community/ara-infra
           - ansible-community/molecule
           - ansible-community/molecule-libvirt
           - ansible-community/molecule-vagrant


### PR DESCRIPTION
ara is moving to GitHub for code review and would like to use Zuul for
testing pull requests.

I have wiped the existing Zuul config for the projects and set them to noop
to hopefully prevent issues.