### PR TITLE
Create new job to refresh AH token

### DIFF
--- a/playbooks/refresh-automation-hub-token/run.yaml
+++ b/playbooks/refresh-automation-hub-token/run.yaml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost
+  tasks:
+    - name: Refresh offline token
+      no_log: true
+      shell: "curl https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token -d grant_type=refresh_token -d client_id=cloud-services -d refresh_token=\"{{ ansible_galaxy_info.token }}\" --fail --silent --show-error --output /dev/null"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -148,6 +148,20 @@
       release_poetry_project: true
 
 - job:
+    name: refresh-automation-hub-token
+    description: |
+      Nightly job to refresh our offline token for automation hub
+
+      See https://access.redhat.com/articles/3626371 for expire information.
+    final: true
+    run: playbooks/refresh-automation-hub-token/run.yaml
+    secrets:
+      - secret: ansible_automation_hub_secret
+        name: ansible_galaxy_info
+    nodeset:
+      nodes: []
+
+- job:
     name: release-ansible-collection-automation-hub
     description: |
       Release ansible collection to https://cloud.redhat.com/ansible/automation-hub

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -810,6 +810,9 @@
     gate:
       jobs:
         - project-config-tox-github
+    periodic-1hr:
+      jobs:
+        - refresh-automation-hub-token
     promote:
       jobs:
         - project-config-github-promote

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -170,26 +170,26 @@
     name: ansible_automation_hub_secret
     data:
       token: !encrypted/pkcs1-oaep
-        - YigReqEB5eGiFS9jTc/U9q4+1rEn7xzupFWUE8Bwn7/yT2UvUAAR0kLkXKQMxGF5MityZ
-          coS7sPEY9/Jm22zGCZgwAh9GTfD1u8QDURKGurGYkjrcEs+9+TdQwXB+muW9gcpgyUX1o
-          /0L+ONDjy30yojp6Xrg/f88XygwSsNLsuZnBMEI6MPT7C5/hcezyOhV2bMVAsSd9YYOlb
-          EdrYozJJ1kc7nBZGA2oWqedco0XUCrQVTDDjKBzTPj7RdUBlxecRpuIycayo56ufv1NoF
-          QDChO99ALcoXN4kj+gPERkXXaNKC0H7waMtfottjOIx5CAVDEZsPVKo9IqRDA7yejHO+f
-          +t81RnNTz2rM38ab0laccJUdOT1gfZKwChaulGCHl1qn8rI3tpgBNlz8Ny5NAh5Pw6Rg9
-          vDHEAmQ/N91+JbIuG+Ph20K8K2huR3XAoWcSAOMrCEM1+6HJqkOAtVv8hOuYxcAlb+VLZ
-          8e77n4mY0rdYKfTF2oiBMZtbUgSUefWb2Wz1qpi7k52cpzL+pW6RTCbEgtKXpN48/UWyq
-          c4NgUqbMa9Rr/xmOL+8BpY8SY1pg6D13+aZpS/jDNG/sDNj2UOpwACbRfbJoRLJh2y9hf
-          rPjflke7pAv5FO9ZSZHvADukp4fzCnuPMnJh4WrsiZBFuFHLQdPE8y0ROp8XjM=
-        - Wn8xfzo+2gw/7IQB2LRazJ5yT8HOn+hfRuhU37jEADsyiP7zl9wSG1uzJE/6k/yWRO50B
-          anhWzf+DwRE7Yui5j9yN80hd/JfD8g/LuZ80jEOos5NXnzqRWixO0NjfU5Ebt1ni5Qupy
-          ZFm7tKUd4hqgDgNrgKBtmxdG0irMHg6QUH8bzcN9FzzYjwc1E/88GphWRd92OcCrRCaUD
-          7CbGpRKo+d9JPG/W0mNjAJCF2B6Wmwx0C/zy5jNp3b1Xlryp95VRqoy3zpf+7q3q45z/H
-          x7qfWxzSveIwioJHYDGWMt+vi4scCZ4OOE1UY8hJ/aINkrTvzrxesdkUkW9FiGZA1GphV
-          EZqwTakfgwbWrQLqd4+1ys/7Digq1Ac4AjfWRPtglCZUTLZJM+6xfxcFrVftSWqDWCnks
-          orzLeNz8ErMk6lJJFr+GgiWSTomWSiFXtxbDro+xMTOzAVWqnGbGzZK/fjVJIgJpz47jr
-          Qp4LgZXWGF/fUyilVNCeiZFv+Vc0teVce0SN+FPScOuMBHD7LGnNN9vrpX+/yZduSOMg9
-          l1x37iJOz3rDUkLfe4KOC7+2EZFvPy3vFH7ap19r0BinHxywsG17P4J4+e6FE0q2JGTB2
-          snT2iaz6teKFiVZpaeaHTadLffyTV9LPHf4g1kG5epfF5BcwmZZb8/52ecY32g=
+        - gc4r4qmK10F7l8vV/zYkQIF9aYa8NF+2EtzzQO1EFWLZ40ud6/rvZJWX3nrJbpj35cOUJ
+          JdYDWE9egKnHpZBWZfJwIDSmptW4kRC12o13UE+Bl2XRDbcttg+65Kpfmtd6YPZL3o8Zw
+          ZJbHHvL6K1UFhIBNE18RogHR1Gg6/vwQBfoi51trzXIPL/+urM1ybXv3zKE6+IEjX+sdB
+          Y1YSIwiazxLpoNPRXZN1Z27kc4jgJeTnGMg4zi5Ay/t9XB5NP1HetiI2T4ZMrqZIw0BLk
+          cCOC+xDiXC4fAChJ5hXHpXrHOhpLUt0VWzRhFUhdlgYNrh0QFkmO4LkwV6FWvt4SUrDmu
+          4y4Pw0OPM9tscycA7WAfK8mO2zJ7n/Rc3i9YGDcw++aYnkbmh7SFKSUdDn0pWNn4E8WtR
+          HVAMe5LgAMAGxJ2BCvDqWzZSbQdQJX7qLRACyWGXm0cMefLbCjykRQ7buJ5ZKVd07iK7v
+          oDwtBbDGXMQdZU+YPvOB9q9Fzj0fj2HZ5dZIU5ldHg/f5gLDmoG4EAPb2evX3BirOyK/n
+          XJr8BCuZpv2nJzODiV4L8DijrFqUjE7FNxRtYzqcVQX2srkxSm6wDH2Jdm5hyrnC+ezqS
+          PBzzfqyCJPnqI/AmWupmVqY2Ldnjn0hlU2FE8rcpOcYN5EJJjyzXCDueph5s6Y=
+        - MUDLiRmBF5FLrykl8YbO0qCcdp8VzwynDYewr6depwqgcKgDhIEZM/zIRH7C2mFWdU+j+
+          +IdxyotkXLUN0opx0Fm7Z0FNb0YC/7zk2U5Eg6bH4if29NINbJQINDvqBnJ8D6T8RFUgr
+          uCg5v3yFbfvT/zGvh8YnL+6JxxS0HkggUbCM0S6DGHs4kzJXyHgOlrjorKblLJkgvutsL
+          E4CYsoAGAB1Aw5iOvui/jZV2vYJvV8/b6PeGIwZgOYgUjtruiQBBUJIWPAaTFYiyd5Wj1
+          BaGg2sZCqn69EAtJ3T33N0/HLGCziNYrEu1aYHx+8yiQr2m+RSwplACVrxQhXiBNIPsRh
+          qVQxXCmOfwDYUOe2d7IXElPKeAjkr3QLPLOwKwAri58VbdFW3ippJ88ergx7NkznrFEch
+          GMNqPkq85cFDg+CV27tGFrUfUTAdPI1/9lqUCCeFr81O/OK0zAWb4mlihYvtX9RU4DCNx
+          RtfoTEhtcpkRiIOVGdztWfDWcNNLCGTfhVeNlotioUU2S4oe7ctTGGZcCDI73oN3Y2kH5
+          uwfZA4/Wv6hR4GN0GbMmB5BkzVSkA3+Z9NlFvMp3+C3V75rUHAcWBjKXVYF3vOOQI1ruA
+          I9ma0kcVsxVsiY0klNmnu8ZkvbGopQ6Oi9NaI16FSUCEBxgukrQbiN6Wi15qHs=
 
 - secret:
     name: galaxy_secret


### PR DESCRIPTION
This both rotates our AH secret and creates a periodic job (1hr for now)
to refresh our token. This is sadly required, as tokens expire after 30
days of inactivity.  I think it is a poor design, especially given there
is no notification about the expire happening.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>