### PR TITLE
Ensure-tox is install for build-ansible-collection job

### DIFF
--- a/playbooks/build-ansible-collection/run.yaml
+++ b/playbooks/build-ansible-collection/run.yaml
@@ -1,6 +1,10 @@
 ---
 - hosts: all
   tasks:
+    - name: Ensure tox
+      include_role:
+        name: ensure-tox
+
     - name: Setup tox role
       include_role:
         name: tox


### PR DESCRIPTION
We'll be removing tox from images soon, so ensure we have it installed
in jobs that use tox.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>