### PR TITLE
c.aws: use publish-to-galaxy

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -172,7 +172,7 @@
     default-branch: main
     templates:
       - system-required
-      - publish-to-galaxy-3pci
+      - publish-to-galaxy
       - ansible-collections-community-aws
 
 - project:


### PR DESCRIPTION
Replace `publish-to-galaxy-3pci` by `publish-to-galaxy`. The collection
will be fully integrated.