### PR TITLE
remove py27 from network-runner jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -613,11 +613,9 @@
     check:
       jobs:
         - ansible-tox-linters
-        - ansible-tox-py27
     gate:
       jobs:
         - ansible-tox-linters
-        - ansible-tox-py27
 
 - project:
     name: github.com/ansible-network/openstack


### PR DESCRIPTION
We're not supporting py27 anymore