### PR TITLE
look for add of a changelog fragment in the whole PR rather than the last commit

### DIFF
--- a/playbooks/ansible-changelog-fragment/run.yaml
+++ b/playbooks/ansible-changelog-fragment/run.yaml
@@ -1,15 +1,35 @@
 ---
+# There is a new changelog fragment, OR: there is a new plugin and no changes
+# of existing files. Fail otherwise.
+
 - hosts: localhost
   gather_facts: false
   tasks:
-    - name: Check for changelog fragments
-      args:
+    - name: Look for changelog fragment
+      command:
         chdir: "{{ zuul.executor.src_root }}/{{ zuul.project.canonical_name }}"
-      shell: git show --name-status --exit-code --oneline --diff-filter=A | grep changelogs/fragments/
-      register: r
-      failed_when: r.rc > 1
+        cmd: "git diff {{ zuul.project.default-branch }} --name-status --exit-code --diff-filter=A -- changelogs/fragments/"
+      register: pr_changelog_fragment
+      failed_when: pr_changelog_fragment.rc > 1
 
-    - name: Changelog fragment failed
-      fail:
-        msg: "Your pull-request is missing a changelog fragment, please add one. It should explain to end users the reason for your change."
-      when: r.rc
+    - name: Look for new plugin
+      command:
+        chdir: "{{ zuul.executor.src_root }}/{{ zuul.project.canonical_name }}"
+        cmd: "git diff {{ zuul.project.default-branch }} --name-status --exit-code --diff-filter=A -- plugins/"
+      register: pr_new_plugin
+      failed_when: pr_new_plugin.rc > 1
+
+    - name: Look for modified and deleted files
+      command:
+        chdir: "{{ zuul.executor.src_root }}/{{ zuul.project.canonical_name }}"
+        cmd: "git diff {{ zuul.project.default-branch }} --name-status --exit-code --diff-filter=MD"
+      register: pr_modified_files
+      failed_when: pr_modified_files.rc > 1
+
+    - name: Assert that a new changelog fragment is present if required
+      assert:
+        that:
+          - pr_changelog_fragment.rc == 1 or
+            pr_new_plugin.rc > pr_modified_files.rc
+        success_msg: "Your pull-request contains a new {{ pr_changelog_fragment.rc | bool | ternary('changelog fragment', 'plugin') }}."
+        fail_msg: "Your pull-request is missing a changelog fragment, please add one. It should explain to end users the reason for your change."

--- a/playbooks/ansible-changelog-fragment/run.yaml
+++ b/playbooks/ansible-changelog-fragment/run.yaml
@@ -1,35 +1,10 @@
 ---
-# There is a new changelog fragment, OR: there is a new plugin and no changes
-# of existing files. Fail otherwise.
-
 - hosts: localhost
   gather_facts: false
+  vars:
+    check_changelog_fragment__git_directory: "{{ zuul.executor.src_root }}/{{ zuul.project.canonical_name }}"
+    check_changelog_fragment__target_branch: "{{ zuul.project.default-branch }}"
   tasks:
-    - name: Look for changelog fragment
-      command:
-        chdir: "{{ zuul.executor.src_root }}/{{ zuul.project.canonical_name }}"
-        cmd: "git diff {{ zuul.project.default-branch }} --name-status --exit-code --diff-filter=A -- changelogs/fragments/"
-      register: pr_changelog_fragment
-      failed_when: pr_changelog_fragment.rc > 1
-
-    - name: Look for new plugin
-      command:
-        chdir: "{{ zuul.executor.src_root }}/{{ zuul.project.canonical_name }}"
-        cmd: "git diff {{ zuul.project.default-branch }} --name-status --exit-code --diff-filter=A -- plugins/"
-      register: pr_new_plugin
-      failed_when: pr_new_plugin.rc > 1
-
-    - name: Look for modified and deleted files
-      command:
-        chdir: "{{ zuul.executor.src_root }}/{{ zuul.project.canonical_name }}"
-        cmd: "git diff {{ zuul.project.default-branch }} --name-status --exit-code --diff-filter=MD"
-      register: pr_modified_files
-      failed_when: pr_modified_files.rc > 1
-
-    - name: Assert that a new changelog fragment is present if required
-      assert:
-        that:
-          - pr_changelog_fragment.rc == 1 or
-            pr_new_plugin.rc > pr_modified_files.rc
-        success_msg: "Your pull-request contains a new {{ pr_changelog_fragment.rc | bool | ternary('changelog fragment', 'plugin') }}."
-        fail_msg: "Your pull-request is missing a changelog fragment, please add one. It should explain to end users the reason for your change."
+    - name: Run check_changelog_fragment role
+      include_role:
+        name: check_changelog_fragment

--- a/roles/check_changelog_fragment/defaults/main.yml
+++ b/roles/check_changelog_fragment/defaults/main.yml
@@ -9,3 +9,6 @@ check_changelog_fragment__target_branch: "main"
 # - diff output is empty: rc = 0
 # - diff output is not empty: rc = 1
 check_changelog_fragment__git_command: "git diff {{ check_changelog_fragment__target_branch }} --name-status --exit-code"
+
+# The documentation about the role's scope
+check_changelog_fragment__reference: "https://docs.ansible.com/ansible/latest/community/development_process.html#changelogs"

--- a/roles/check_changelog_fragment/defaults/main.yml
+++ b/roles/check_changelog_fragment/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# The root directory of the project
+check_changelog_fragment__git_directory: "."
+
+# The target branch of the pull-request
+check_changelog_fragment__target_branch: "main"
+
+# Option '--exit-code' makes 'git diff' behaves as 'diff':
+# - diff output is empty: rc = 0
+# - diff output is not empty: rc = 1
+check_changelog_fragment__git_command: "git diff {{ check_changelog_fragment__target_branch }} --name-status --exit-code"

--- a/roles/check_changelog_fragment/tasks/main.yml
+++ b/roles/check_changelog_fragment/tasks/main.yml
@@ -20,6 +20,15 @@
   changed_when: check_changelog_fragment__rebase.stdout_lines | length > 1
 
 
+- name: Look for any diff between current and target branches
+  command:
+    cmd: "{{ check_changelog_fragment__git_command }}"
+    chdir: "{{ check_changelog_fragment__git_directory }}"
+  register: check_changelog_fragment__any_change
+  failed_when: check_changelog_fragment__any_change.rc > 1
+  changed_when: false
+
+
 - name: Look for a new changelog fragment
   command:
     cmd: "{{ check_changelog_fragment__git_command }} --diff-filter=A -- changelogs/fragments/"
@@ -52,11 +61,13 @@
 - name: Assert that a new changelog fragment is present if required
   assert:
     that:
-      - check_changelog_fragment__new_fragment.rc == 1 or
+      - check_changelog_fragment__any_change.rc == 0 or
+        check_changelog_fragment__new_fragment.rc == 1 or
         check_changelog_fragment__new_plugin.rc > check_changelog_fragment__changed_files.rc
     success_msg: >-
       Your pull-request contains a new {{ 'changelog fragment' if
       check_changelog_fragment__new_fragment.rc | bool else 'plugin' }}.
     fail_msg: >-
       Your pull-request is missing a changelog fragment, please add one.
-      It should explain to end users the reason for your change.
+      It should explain to end users the reason for your change. See
+      {{ check_changelog_fragment__reference }}

--- a/roles/check_changelog_fragment/tasks/main.yml
+++ b/roles/check_changelog_fragment/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+# RULES
+# * a pull-request needs a new changelog fragment
+# * unless:
+#   * it is a "New plugin" pull-request
+#   * unless:
+#     * the PR modifies existing file(s)
+#     * the PR deletes existing file(s)
+#     * the PR renames existing file(s)
+
+
+# Rebasing ensures diffs are related to the PR, and only to the PR. If the task
+# fails, this is because of conflicts, i.e. the PR is not ready for merging (or
+# one of git_directory or target_branch is incorrect).
+- name: Rebase the PR branch on the top of the target branch
+  command:
+    chdir: "{{ check_changelog_fragment__git_directory }}"
+    cmd: "git rebase {{ check_changelog_fragment__target_branch }}"
+  register: check_changelog_fragment__rebase
+  changed_when: check_changelog_fragment__rebase.stdout_lines | length > 1
+
+
+- name: Look for a new changelog fragment
+  command:
+    cmd: "{{ check_changelog_fragment__git_command }} --diff-filter=A -- changelogs/fragments/"
+    chdir: "{{ check_changelog_fragment__git_directory }}"
+  register: check_changelog_fragment__new_fragment
+  failed_when: check_changelog_fragment__new_fragment.rc > 1
+  changed_when: false
+
+
+- name: Look for a new plugin
+  command:
+    cmd: "{{ check_changelog_fragment__git_command }} --diff-filter=A -- plugins/"
+    chdir: "{{ check_changelog_fragment__git_directory }}"
+  register: check_changelog_fragment__new_plugin
+  failed_when: check_changelog_fragment__new_plugin.rc > 1
+  changed_when: false
+
+
+- name: Look for changes of existing files (modified, deleted, renamed)
+  command:
+    cmd: "{{ check_changelog_fragment__git_command }} --diff-filter=MDR"
+    chdir: "{{ check_changelog_fragment__git_directory }}"
+  register: check_changelog_fragment__changed_files
+  failed_when: check_changelog_fragment__changed_files.rc > 1
+  changed_when: false
+
+
+# There is a new changelog fragment (rc=1) OR: there is a new plugin (rc=1) AND
+# no changes of existing files (rc=0).
+- name: Assert that a new changelog fragment is present if required
+  assert:
+    that:
+      - check_changelog_fragment__new_fragment.rc == 1 or
+        check_changelog_fragment__new_plugin.rc > check_changelog_fragment__changed_files.rc
+    success_msg: >-
+      Your pull-request contains a new {{ 'changelog fragment' if
+      check_changelog_fragment__new_fragment.rc | bool else 'plugin' }}.
+    fail_msg: >-
+      Your pull-request is missing a changelog fragment, please add one.
+      It should explain to end users the reason for your change.


### PR DESCRIPTION
Fixes #771 

#### RATIONALE

The current `ansible-changelog-fragment` check leads to many false positives:
- When a new commit is added and is not squashed with the one adding the changelog fragment.
- When the pull-request contains a new plugin (module, filter, lookup...) and no changes of existing files.

This PR is a refactor of the whole check to look for add of a changelog fragment in the entire PR rather that just the last commit, and to not fail when a changelog fragment is not required.