### PR TITLE
Add acl-config setting for ansible_content_collections_metrics

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -128,6 +128,7 @@
 - project: ansible-network/ansible-zuul-jobs
   description: Defines test jobs and roles
 - project: ansible-network/ansible_content_collections_metrics
+  acl-config: acls/ansible-network/ansible_content_collections_metrics.config
   description: The GUI provides a dashboard in terms of factual metrics system for the github projects managed by Ansible for content collections.
   default-branch: main
 - project: ansible-network/aws_management


### PR DESCRIPTION
Not sure why, but acls didn't apply.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>