### PR TITLE
Add community.dns as tenant

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -110,6 +110,7 @@
               - ansible-collections/community.cassandra
               - ansible-collections/community.crypto
               - ansible-collections/community.digitalocean
+              - ansible-collections/community.dns
               - ansible-collections/community.docker
               - ansible-collections/community.fortios
               - ansible-collections/community.general


### PR DESCRIPTION
New community collection that exists since today (https://github.com/ansible-collections/community.dns).

CC @gundalow