### PR TITLE
mitigate PR 772 impact and add a fix

### DIFF
--- a/playbooks/ansible-changelog-fragment/run.yaml
+++ b/playbooks/ansible-changelog-fragment/run.yaml
@@ -1,10 +1,15 @@
 ---
 - hosts: localhost
   gather_facts: false
-  vars:
-    check_changelog_fragment__git_directory: "{{ zuul.executor.src_root }}/{{ zuul.project.canonical_name }}"
-    check_changelog_fragment__target_branch: "{{ zuul.project.default-branch }}"
   tasks:
-    - name: Run check_changelog_fragment role
-      include_role:
-        name: check_changelog_fragment
+    - name: Check for changelog fragments
+      args:
+        chdir: "{{ zuul.executor.src_root }}/{{ zuul.project.canonical_name }}"
+      shell: git show --name-status --exit-code --oneline --diff-filter=A | grep changelogs/fragments/
+      register: r
+      failed_when: r.rc > 1
+
+    - name: Changelog fragment failed
+      fail:
+        msg: "Your pull-request is missing a changelog fragment, please add one. It should explain to end users the reason for your change."
+      when: r.rc

--- a/playbooks/ansible-changelog-fragment/run_with_check_changelog_fragment.yaml
+++ b/playbooks/ansible-changelog-fragment/run_with_check_changelog_fragment.yaml
@@ -1,0 +1,10 @@
+---
+- hosts: localhost
+  gather_facts: false
+  vars:
+    check_changelog_fragment__git_directory: "{{ zuul.executor.src_root }}/{{ zuul.project.canonical_name }}"
+    check_changelog_fragment__target_branch: "{{ zuul.project['default-branch'] }}"
+  tasks:
+    - name: Run check_changelog_fragment role
+      include_role:
+        name: check_changelog_fragment

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -84,6 +84,16 @@
       nodes: []
 
 - job:
+    name: ansible-changelog-fragment_2
+    description: Ensure PRs have generated changelog fragments, test PR 801
+    run: playbooks/ansible-changelog-fragment/run_with_check_changelog_fragment.yaml
+    files:
+      - ^plugins/.*$
+      - ^tests/.*$
+    nodeset:
+      nodes: []
+
+- job:
     name: project-config-tox-github
     parent: tox
     description: |


### PR DESCRIPTION
- `{{ zuul.project.default-branch }}` -> `{{ zuul.project['default-branch'] }}`
- use `playbooks/ansible-changelog-fragment/run_with_check_changelog_fragment.yaml`
  to be able to test the role
- new job: ansible-changelog-fragment_2 (for testing)