### PR TITLE
ansible-changelog-fragment: get the default branch

### DIFF
--- a/playbooks/ansible-changelog-fragment/run_with_check_changelog_fragment.yaml
+++ b/playbooks/ansible-changelog-fragment/run_with_check_changelog_fragment.yaml
@@ -1,10 +1,17 @@
 ---
 - hosts: localhost
   gather_facts: false
-  vars:
-    check_changelog_fragment__git_directory: "{{ zuul.executor.src_root }}/{{ zuul.project.canonical_name }}"
-    check_changelog_fragment__target_branch: "{{ zuul.project['default-branch'] }}"
   tasks:
-    - name: Run check_changelog_fragment role
-      include_role:
-        name: check_changelog_fragment
+    - when: zuul.project.canonical_hostname == "github.com"
+      block:
+        - name: Retrieve the details about the Github project
+          uri:
+            url: "https://api.github.com/repos/{{ zuul.project.name }}"
+            return_content: true
+          register: project_details
+        - name: Run check_changelog_fragment role
+          include_role:
+            name: check_changelog_fragment
+          vars:
+            check_changelog_fragment__git_directory: "{{ zuul.executor.src_root }}/{{ zuul.project.canonical_name }}"
+            check_changelog_fragment__target_branch: "{{ project_details.json.default_branch }}"


### PR DESCRIPTION
Get the default branch using the Github API.