### PR TITLE
Set ssh key size as 2048 for rsa key

### DIFF
--- a/playbooks/base-minimal-test/pre.yaml
+++ b/playbooks/base-minimal-test/pre.yaml
@@ -17,6 +17,8 @@
     - name: Run add-build-sshkey role (RSA)
       include_role:
         name: add-build-sshkey
+      vars:
+        zuul_ssh_key_size: 2048
 
     - name: Run add-build-sshkey role (ECDSA)
       include_role:


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

Zuul sets rsa key size as 3072, which causes failure in asa applaince.
This PR sets the rsa key size as 2048 for all appliances.