### PR TITLE
tenant: add vmware/vsphere-automation-sdk-python

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -142,6 +142,7 @@
               - ansible/pylibssh
               - ansible/workshops
               - vmware/govmomi
+              - vmware/vsphere-automation-sdk-python
 
       github-3pci:
         untrusted-projects: []


### PR DESCRIPTION
The goal is to precache vmware/vsphere-automation-sdk-python.