### PR TITLE
search for a changelog fragment in the whole PR

### DIFF
--- a/playbooks/ansible-changelog-fragment/run.yaml
+++ b/playbooks/ansible-changelog-fragment/run.yaml
@@ -5,11 +5,11 @@
     - name: Check for changelog fragments
       args:
         chdir: "{{ zuul.executor.src_root }}/{{ zuul.project.canonical_name }}"
-      shell: git show --name-status --exit-code --oneline --diff-filter=A | grep changelogs/fragments/
+      command: "git diff origin/{{ zuul.branch }} HEAD --name-status --exit-code --diff-filter=A -- changelogs/fragments/"
       register: r
       failed_when: r.rc > 1
 
     - name: Changelog fragment failed
       fail:
         msg: "Your pull-request is missing a changelog fragment, please add one. It should explain to end users the reason for your change."
-      when: r.rc
+      when: not r.rc


### PR DESCRIPTION
### SUMMARY

It would be nice to not fail the tests when a contributor applies changes suggested by a reviewer through github's builtin feature, `apply changes` button.

This PR allows one to validate this test (*ansible-changelog-fragment*) without the need to interactively squash its branch when the changelog fragment has been added in a **previous** commit.