### PR TITLE
Reconfigure molecule-libvirt

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -500,8 +500,7 @@
 - project:
     name: github.com/ansible-community/molecule-libvirt
     templates:
-      - publish-to-pypi
-      - system-required
+      - noop-jobs
 
 - project:
     name: github.com/ansible-community/molecule-vagrant


### PR DESCRIPTION
Use the same configuration as molecule-vagrant, where zuul is only used as a 3rd party CI.