### PR TITLE
Drop ansible 2.8 testing for ansible-runner

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -782,8 +782,6 @@
       - publish-to-pypi
     check:
       jobs:
-        - ansible-runner-tox-ansible28:
-            branches: 'devel'
         - ansible-runner-tox-ansible29:
             branches: 'devel'
         - ansible-runner-tox-ansible-base:  # not expecting older stable versions to support ansible-base
@@ -794,8 +792,6 @@
             branches: '^stable/1.*'
     gate:
       jobs:
-        - ansible-runner-tox-ansible28:
-            branches: 'devel'
         - ansible-runner-tox-ansible29:
             branches: 'devel'
         - ansible-runner-tox-ansible-base:  # not expecting older stable versions to support ansible-base


### PR DESCRIPTION
Ansible 2.8 is EOL, lets stop testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>