### PR TITLE
Stop using venv for ansible-network/releases

### DIFF
--- a/playbooks/ansible-collection/run-pre.yaml
+++ b/playbooks/ansible-collection/run-pre.yaml
@@ -5,7 +5,7 @@
       include_role:
         name: tox
       vars:
-        tox_envlist: venv
+        tox_envlist: generate_ansible_collection
         tox_extra_args: -vv --notest
         tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
@@ -13,4 +13,4 @@
     - name: Generate version number for ansible collection.
       args:
         chdir: "{{ zuul.project.src_dir }}"
-      command: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/generate-ansible-collection"
+      command: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/generate_ansible_collection/bin/generate-ansible-collection"

--- a/playbooks/ansible-collection/run.yaml
+++ b/playbooks/ansible-collection/run.yaml
@@ -5,5 +5,5 @@
       include_role:
         name: build-ansible-collection
       vars:
-        ansible_galaxy_executable: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/ansible-galaxy"
+        ansible_galaxy_executable: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/generate_ansible_collection/bin/ansible-galaxy"
         ansible_galaxy_output_path: "{{ ansible_user_dir }}/artifacts"

--- a/playbooks/build-ansible-collection/run.yaml
+++ b/playbooks/build-ansible-collection/run.yaml
@@ -5,7 +5,7 @@
       include_role:
         name: tox
       vars:
-        tox_envlist: venv
+        tox_envlist: generate_ansible_collection
         tox_extra_args: -vv --notest
         tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
@@ -13,14 +13,14 @@
     - name: Generate version number for ansible collection
       args:
         chdir: "{{ ansible_user_dir }}/{{ item.src_dir }}"
-      shell: "if test -f 'galaxy.yml'; then {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/generate-ansible-collection; fi"
+      shell: "if test -f 'galaxy.yml'; then {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/generate_ansible_collection/bin/generate-ansible-collection; fi"
       with_items: "{{ zuul.projects.values() | list }}"
 
     - name: Run build-ansible-collection role
       include_role:
         name: build-ansible-collection
       vars:
-        ansible_galaxy_executable: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/ansible-galaxy"
+        ansible_galaxy_executable: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/generate_ansible_collection/bin/ansible-galaxy"
         ansible_galaxy_output_path: "{{ ansible_user_dir }}/artifacts"
         zuul_work_dir: "{{ ansible_user_dir }}/{{ item.src_dir }}"
       with_items: "{{ zuul.projects.values() | list }}"


### PR DESCRIPTION
This move to another tox entry point, to reduce the dependencies we pull
in.

Depends-On: https://github.com/ansible-network/releases/pull/17
Signed-off-by: Paul Belanger <pabelanger@redhat.com>