### PR TITLE
Remove status file from check pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -20,18 +20,15 @@
       github.com:
         check: in_progress
         comment: false
-        status: 'pending'
     success:
       github.com:
         check: success
         comment: false
-        status: 'success'
       mysql:
     failure:
       github.com:
         check: failure
         comment: false
-        status: 'failure'
       mysql:
 
 - pipeline:


### PR DESCRIPTION
With the upgrade to zuul 4.5.1, we likely no longer need to do this.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>