### PR TITLE
Remove status from gate pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -63,19 +63,16 @@
       github.com:
         check: in_progress
         comment: false
-        status: 'pending'
     success:
       github.com:
         check: success
         comment: false
         merge: true
-        status: 'success'
       mysql:
     failure:
       github.com:
         check: failure
         comment: false
-        status: 'failure'
       mysql:
     window-floor: 20
     window-increase-factor: 2


### PR DESCRIPTION
Continue removing references to old checks api in our pipeline config.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>