### PR TITLE
Stop publishing ara-report / htmlify logs

### DIFF
--- a/playbooks/base-minimal-test/post-logs.yaml
+++ b/playbooks/base-minimal-test/post-logs.yaml
@@ -2,14 +2,6 @@
 - hosts: localhost
   gather_facts: false
   tasks:
-    - name: Run ara-report role
-      include_role:
-        name: ara-report
-
-    - name: Run htmlify-logs role
-      include_role:
-        name: htmlify-logs
-
     - name: Run Zuul manifest role
       include_role:
         name: generate-zuul-manifest

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -60,11 +60,6 @@
       - zuul: opendev.org/zuul/zuul-jobs
     post-timeout: 3600
     timeout: 1800
-    vars:
-      ara_report_executable: "/opt/venv/zuul-ansible/{{ ansible_version.full }}/bin/ara"
-      ara_report_type: html
-      ara_report_path: "{{ zuul.executor.log_root }}/ara-report"
-      ara_compress_html: false
     secrets:
       - rackspace_dfw_clouds_yaml
       - rackspace_iad_clouds_yaml


### PR DESCRIPTION
We can now leverage zuul-web for this logic.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>