### PR TITLE
Allow recheck to trigger gate pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -61,6 +61,9 @@
         - event: pull_request
           action: labeled
           label: gate
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s*$
     start:
       github.com:
         check: in_progress


### PR DESCRIPTION
Now that we superceed check, we should allow for this to happen.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>