### PR TITLE
Remove check_run trigger for gate pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -55,9 +55,6 @@
         current-patchset: true
     trigger:
       github.com:
-        - event: check_run
-          action: completed
-          check: "ansible-zuul:ansible/check:success"
         - event: pull_request
           action: labeled
           label: gate


### PR DESCRIPTION
This is no longer needed since we removed the clean check requirement.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>