### PR TITLE
Don't report merge failures for check pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -32,6 +32,8 @@
       github.com:
         check: cancelled
         comment: false
+    # Don't report merge-failures to github.com
+    merge-failure: {}
 
 - pipeline:
     name: gate


### PR DESCRIPTION
Do this until we can migrate ansible/ansible to our 3pci github app.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>