### PR TITLE
Remove ansible/awx-ee project

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -206,10 +206,6 @@
   default-branch: main
 - project: ansible/ansible-zuul-jobs
   description: Zuul job definitions for the Ansible tenant.
-- project: ansible/awx-ee
-  description: An Ansible execution environment for AWX project
-  default-branch: devel
-  homepage: https://quay.io/ansible/awx-ee
 - project: ansible/cloud-ee
   description: An Ansible execution environment for Ansible Cloud Collections
   default-branch: main

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -876,12 +876,6 @@
       jobs: []
 
 - project:
-    name: github.com/ansible/awx-ee
-    default-branch: devel
-    templates:
-      - system-required
-
-- project:
     name: github.com/ansible/cloud-ee
     default-branch: main
     templates:

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -22,7 +22,6 @@
           - ansible/ansible-core-image
           - ansible/ansible-navigator
           - ansible/ansible-runner
-          - ansible/awx-ee
           - ansible/python-base-image
           - ansible/python-builder-image
           - ansible-collections/amazon.aws


### PR DESCRIPTION
This project has moved to github access, we also no longer have admin
access on it to properly configure it for zuul. This fixes our promote
job.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>