### PR TITLE
Promote LGTM logic to gate pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -68,6 +68,8 @@
         check: success
         comment: false
         merge: true
+        review: approve
+        review-body: "LGTM!"
     failure:
       github.com:
         check: failure
@@ -269,8 +271,6 @@
       github.com:
         comment: false
         status: success
-        review: approve
-        review-body: "LGTM!"
     failure:
       github.com:
         comment: false


### PR DESCRIPTION
Lets see if we can move the LGTM logic to the gate pipeline, and not
race before the merge request.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>