### PR TITLE
Revert "Promote LGTM logic to gate pipeline"

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -68,8 +68,6 @@
         check: success
         comment: false
         merge: true
-        review: approve
-        review-body: "LGTM!"
     failure:
       github.com:
         check: failure
@@ -271,6 +269,8 @@
       github.com:
         comment: false
         status: success
+        review: approve
+        review-body: "LGTM!"
     failure:
       github.com:
         comment: false


### PR DESCRIPTION
This reverts commit e90903ad203929868fa42c10f80e1863ca4ac0c5.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>