### PR TITLE
Simplify the lgtm pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -266,24 +266,10 @@
         - event: pull_request
           action: labeled
           label: gate
-    start:
-      github.com:
-        check: in_progress
-        comment: false
     success:
       github.com:
-        check: success
-        comment: false
         review: approve
         review-body: "LGTM!"
-    failure:
-      github.com:
-        check: failure
-        comment: false
-    dequeue:
-      github.com:
-        check: cancelled
-        comment: false
 
 - pipeline:
     name: merge-check


### PR DESCRIPTION
We don't need to report back to the checks API for this pipeline.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>