### PR TITLE
Add galaxy / AH publish jobs to ansible-collections/ansible.windows

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -88,6 +88,23 @@
       - publish-to-automation-hub
 
 - project:
+    name: github.com/ansible-collections/ansible.windows
+    default-branch: main
+    templates:
+      - publish-to-galaxy-3pci
+    pre-release:
+      jobs:
+        - release-ansible-collection-automation-hub
+    release:
+      jobs:
+        - release-ansible-collection-automation-hub
+        - release-ansible-collection-announcement:
+            dependencies:
+              - name: release-ansible-collection-automation-hub
+              - name: release-ansible-collection-galaxy
+                soft: true
+
+- project:
     name: github.com/ansible-collections/arista.eos
     default-branch: main
     merge-mode: squash-merge

--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -138,7 +138,6 @@
               - ansible-collections/community.windows
               - ansible-collections/community.zabbix
               - ansible-collections/hetzner.hcloud
-              - ansible-collections/kubernetes.core
               - ansible/awx
               - ansible/galaxy
               - ansible/galaxy_ng


### PR DESCRIPTION
This will users to git tag a release for ansible.windows and collections
to be publish to galaxy / AH.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>