### PR TITLE
Move check pipeline to skipped

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -30,7 +30,7 @@
         comment: false
     dequeue:
       github.com:
-        check: cancelled
+        check: skipped
         comment: false
 
 - pipeline:


### PR DESCRIPTION
When we dequeue jobs to move them into gate (superceed) we don't want a
red error.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>