### PR TITLE
Remove release-ansible-collection-announcement job

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -98,11 +98,6 @@
     release:
       jobs:
         - release-ansible-collection-automation-hub
-        - release-ansible-collection-announcement:
-            dependencies:
-              - name: release-ansible-collection-automation-hub
-              - name: release-ansible-collection-galaxy
-                soft: true
 
 - project:
     name: github.com/ansible-collections/arista.eos


### PR DESCRIPTION
The job is currently broken because of a twitter API change upstream:

  https://github.com/bear/python-twitter/issues/695

Signed-off-by: Paul Belanger <pabelanger@redhat.com>