### PR TITLE
Remove ansible-python3-jobs template from ansible-runner project

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -864,7 +864,6 @@
       - system-required
       - execution-environments-queue
       - ansible-python-jobs   # linting-only
-      - ansible-python3-jobs  # py3 tox jobs
       - publish-to-pypi
     check:
       jobs:


### PR DESCRIPTION
`ansible-runner` is defining the py38 job in its repo and no longer needs py36 and py37 jobs.

Depends-On: https://github.com/ansible/ansible-runner/pull/768