### PR TITLE
Also run lgtm jobs on recheck

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -271,6 +271,9 @@
         - event: pull_request
           action: labeled
           label: gate
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s*$
     success:
       github.com:
         comment: false


### PR DESCRIPTION
This deals with the issue where gate gets applied, but for whatever
reason lgtm isn't triggered properly.  This shouldn't happen often, but
adding this should be pretty safe.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>