### PR TITLE
Reorder gate to see if sempahore works better

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -1,39 +1,5 @@
 ---
 - pipeline:
-    name: check
-    description: |
-      Newly uploaded patchsets enter this pipeline to receive an
-      initial +/-1 Verified vote.
-    manager: independent
-    precedence: normal
-    trigger:
-      github.com:
-        - event: pull_request
-          action:
-            - opened
-            - changed
-            - reopened
-        - event: pull_request
-          action: comment
-          comment: (?i)^\s*recheck\s*$
-    start:
-      github.com:
-        check: in_progress
-        comment: false
-    success:
-      github.com:
-        check: success
-        comment: false
-    failure:
-      github.com:
-        check: failure
-        comment: false
-    dequeue:
-      github.com:
-        check: skipped
-        comment: false
-
-- pipeline:
     name: gate
     description: |
       Changes that have been approved by core developers are enqueued
@@ -81,6 +47,40 @@
         comment: false
     window-floor: 20
     window-increase-factor: 2
+
+- pipeline:
+    name: check
+    description: |
+      Newly uploaded patchsets enter this pipeline to receive an
+      initial +/-1 Verified vote.
+    manager: independent
+    precedence: normal
+    trigger:
+      github.com:
+        - event: pull_request
+          action:
+            - opened
+            - changed
+            - reopened
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*recheck\s*$
+    start:
+      github.com:
+        check: in_progress
+        comment: false
+    success:
+      github.com:
+        check: success
+        comment: false
+    failure:
+      github.com:
+        check: failure
+        comment: false
+    dequeue:
+      github.com:
+        check: skipped
+        comment: false
 
 - pipeline:
     name: post


### PR DESCRIPTION
This is an experiment to confirm semaphores are help based on pipeline
config order.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>