### PR TITLE
Don't always run push-to-intermediate-registry

### DIFF
--- a/playbooks/buildset-registry/post.yaml
+++ b/playbooks/buildset-registry/post.yaml
@@ -4,3 +4,4 @@
     - name: Run push-to-intermediate-registry role
       include_role:
         name: push-to-intermediate-registry
+      when: buildset_registry is not defined

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -15,6 +15,7 @@
     require:
       github.com:
         label: gate
+        status: "ansible-zuul:ansible/check:(skipped|success)"
         open: true
         current-patchset: true
     trigger:


### PR DESCRIPTION
If we are not the buildset-registry, we don't want to push our images.
The buildset-registry will handle it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>