### PR TITLE
Actually require ansible/check status for gate pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -15,6 +15,7 @@
     require:
       github.com:
         label: gate
+        status: "ansible-zuul:ansible/check:(skipped|success)"
         open: true
         current-patchset: true
     trigger:


### PR DESCRIPTION
This should stop failed check pipeline from being enqueued into gate.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>