### PR TITLE
Remove python3-jobs from ansible-builder

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -838,7 +838,6 @@
       - execution-environments-queue
       - system-required
       - ansible-python-jobs
-      - ansible-python3-jobs
       - publish-to-pypi
 
 - project:


### PR DESCRIPTION
These are now managed in-tree.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>