### PR TITLE
Allow re-run of failure check jobs

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -16,6 +16,9 @@
         - event: pull_request
           action: comment
           comment: (?i)^\s*recheck\s*$
+        - event: check_run
+          action: rerequested
+          check: "ansible-zuul:ansible/check:failure"
     start:
       github.com:
         check: in_progress


### PR DESCRIPTION
This will allow a user to re-run a failed check_run.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>