### PR TITLE
Add new pipeline to run aws complete ci in

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -401,17 +401,17 @@
     merge-failure: {}
 
 - pipeline:
-    name: aws-complete
-    description: On-demand pipeline for requesting a run against the complete set of integration tests in this collection. Leave review comment of "check aws-complete" to run jobs in this pipeline.
-    success-message: Build succeeded (aws-complete pipeline).
-    failure-message: Build failed (aws-complete pipeline).
+    name: ondemand
+    description: On-demand pipeline for requesting a run of optional tests in a collection. Leave review comment of "check ondemand" to run jobs in this pipeline.
+    success-message: Build succeeded (ondemand pipeline).
+    failure-message: Build failed (ondemand pipeline).
     manager: independent
     precedence: low
     trigger:
       github.com:
         - event: pull_request
           action: comment
-          comment: (?i)^\s*check aws?complete\s*$
+          comment: (?i)^\s*check ondemand\s*$
     success:
       github.com: {}
     failure:

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -399,3 +399,20 @@
           comment: (?i)^\s*recheck\s*$
     # Don't report merge-failures to github.com
     merge-failure: {}
+
+- pipeline:
+    name: aws-complete
+    description: On-demand pipeline for requesting a run against the complete set of integration tests in this collection. Leave review comment of "check aws-complete" to run jobs in this pipeline.
+    success-message: Build succeeded (aws-complete pipeline).
+    failure-message: Build failed (aws-complete pipeline).
+    manager: independent
+    precedence: low
+    trigger:
+      github.com:
+        - event: pull_request
+          action: comment
+          comment: (?i)^\s*check aws?complete\s*$
+    success:
+      github.com: {}
+    failure:
+      github.com: {}

--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -403,8 +403,6 @@
 - pipeline:
     name: ondemand
     description: On-demand pipeline for requesting a run of optional tests in a collection. Leave review comment of "check ondemand" to run jobs in this pipeline.
-    success-message: Build succeeded (ondemand pipeline).
-    failure-message: Build failed (ondemand pipeline).
     manager: independent
     precedence: low
     trigger:
@@ -412,7 +410,15 @@
         - event: pull_request
           action: comment
           comment: (?i)^\s*check ondemand\s*$
+    start:
+      github.com:
+        check: in_progress
+        comment: false
     success:
-      github.com: {}
+      github.com:
+        check: success
+        comment: false
     failure:
-      github.com: {}
+      github.com:
+        check: failure
+        comment: false


### PR DESCRIPTION
The glob in `check aws?complete` is intentional. I think it's reasonable to accept common typos like `aws-complete`, `aws_complete`, and `aws complete`. 