### PR TITLE
Revert "amazon.aws: temp turn on the merge strategy"

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -9,6 +9,7 @@
 - project:
     name: github.com/ansible-collections/amazon.aws
     default-branch: main
+    merge-mode: squash-merge
     templates:
       - system-required
       - publish-to-galaxy


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/435
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/410

This reverts commit 7dd6b71226c760793cbb1ff2383f9b5b1fc20c20 since we
don't need it anymore.