### PR TITLE
adjust the default-branch of some repositories

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -131,6 +131,7 @@
 - project: ansible-community/molecule
   description: Molecule aids in the development and testing of Ansible roles
 - project: ansible-community/molecule-libvirt
+  default-branch: main
   description: Molecule LibVirt Provider
 - project: ansible-network/ansible-zuul-jobs
   description: Defines test jobs and roles

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -233,80 +233,96 @@
 
 - project:
     name: github.com/ansible-collections/community.ciscosmb
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.crypto
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.digitalocean
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 - project:
     name: github.com/ansible-collections/community.dns
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 - project:
     name: github.com/ansible-collections/community.docker
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.fortios
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.general
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.google
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.grafana
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.hashi_vault
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.hrobot
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.internal_test_tools
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.kubernetes
+    default-branch: main
     templates:
       - ansible-collections-community-kubernetes
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.kubevirt
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.libvirt
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.molecule
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
@@ -317,42 +333,51 @@
 
 - project:
     name: github.com/ansible-collections/community.mysql
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.network
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
+# TODO: This repository has been renamed to github.com/openshift/community.okd
 - project:
     name: github.com/ansible-collections/community.okd
+    default-branch: main
     templates:
       - ansible-collections-community-okd
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.postgresql
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.proxysql
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.rabbitmq
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.routeros
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
 - project:
     name: github.com/ansible-collections/community.sops
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
@@ -368,6 +393,7 @@
 
 - project:
     name: github.com/ansible-collections/community.windows
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
@@ -385,6 +411,7 @@
 
 - project:
     name: github.com/ansible-collections/community.zabbix
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
@@ -404,6 +431,7 @@
 
 - project:
     name: github.com/ansible-collections/hetzner.hcloud
+    default-branch: main
     templates:
       - publish-to-galaxy-3pci
 
@@ -572,11 +600,13 @@
 
 - project:
     name: github.com/ansible-community/molecule-libvirt
+    default-branch: main
     templates:
       - noop-jobs
 
 - project:
     name: github.com/ansible-community/molecule-vagrant
+    default-branch: main
     templates:
       - noop-jobs
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible/project-config/pull/931

These repositories are now using `main` as their default branch. This
commit adjust Zuul's configuration.

Closes: https://github.com/ansible/project-config/issues/929