### PR TITLE
ansible-community/molecule uses main as default branch

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -130,6 +130,7 @@
   description: ansible-playbook + buildah = a sweet container image
 - project: ansible-community/molecule
   description: Molecule aids in the development and testing of Ansible roles
+  default-branch: main
 - project: ansible-community/molecule-libvirt
   default-branch: main
   description: Molecule LibVirt Provider

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -599,6 +599,12 @@
       - system-required
 
 - project:
+    name: github.com/ansible-community/molecule
+    default-branch: main
+    templates:
+      - noop-jobs
+
+- project:
     name: github.com/ansible-community/molecule-libvirt
     default-branch: main
     templates:


### PR DESCRIPTION
- add ansible-community/molecule in Zuul
- use main as default-branch.