### PR TITLE
Enable community.okd at the new repo location

### DIFF
--- a/github/projects.yaml
+++ b/github/projects.yaml
@@ -235,3 +235,6 @@
 - project: ansible/workshops
   description: Training Course for Ansible Automation Platform
   default-branch: devel
+- project: openshift/community.okd
+  description: OKD/Openshift collection for Ansible
+  default-branch: main

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -344,7 +344,7 @@
       - publish-to-galaxy-3pci
 
 - project:
-    name: github.com/openshift/community.okd
+    name: github.com/ansible-collections/community.okd
     default-branch: main
     templates:
       - ansible-collections-community-okd
@@ -1003,6 +1003,13 @@
         - workshops-tox-integration-security
         - workshops-tox-integration-smart-mgmt
         - workshops-tox-integration-windows
+
+- project:
+    name: github.com/openshift/community.okd
+    default-branch: main
+    templates:
+      - ansible-collections-community-okd
+      - publish-to-galaxy-3pci
 
 - project:
     name: github.com/pabelanger/pabelanger-sandbox1

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -343,9 +343,8 @@
     templates:
       - publish-to-galaxy-3pci
 
-# TODO: This repository has been renamed to github.com/openshift/community.okd
 - project:
-    name: github.com/ansible-collections/community.okd
+    name: github.com/openshift/community.okd
     default-branch: main
     templates:
       - ansible-collections-community-okd


### PR DESCRIPTION
This collection got moved under the openshift org. I'm not sure if there is something else that needs to be done to turn this on for the collection. I believe zuul should have the permissions it needs on that repo.