### PR TITLE
Remove ansible-navigator-jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -885,7 +885,6 @@
     merge-mode: squash-merge
     templates:
       - system-required
-      - ansible-navigator-jobs
       - publish-to-pypi
 
 - project:


### PR DESCRIPTION
We are moving these jobs in-repo for better control over them.

Required-By: https://github.com/ansible/ansible-zuul-jobs/pull/1100