### PR TITLE
Upgrade to ubuntu-bionic-2vcpu for buildset-registry

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -259,7 +259,7 @@
     pre-run: playbooks/buildset-registry/pre.yaml
     run: playbooks/buildset-registry/run.yaml
     post-run: playbooks/buildset-registry/post.yaml
-    nodeset: ubuntu-bionic-1vcpu
+    nodeset: ubuntu-bionic-2vcpu
     vars:
       container_command: docker
     secrets:


### PR DESCRIPTION
This should stop this job from running on AWS, which is where we are
seeing failures.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>