### PR TITLE
do not publish community.okd on AH

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1008,7 +1008,6 @@
     templates:
       - ansible-collections-community-okd
       - publish-to-galaxy-3pci
-      - publish-to-automation-hub-3pci
 
 - project:
     name: github.com/pabelanger/pabelanger-sandbox1


### PR DESCRIPTION
redhat.openshift is based on community.okd, but it's a manual process.

See: https://github.com/ansible/ansible-zuul-jobs/pull/1121#issuecomment-924131723
