### PR TITLE
Moving runner linter job to runner repo

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -892,7 +892,6 @@
     templates:
       - system-required
       - execution-environments-queue
-      - ansible-python-jobs   # linting-only
       - publish-to-pypi
     check:
       jobs:


### PR DESCRIPTION
We'd like to use python 3.8 in the `ansible-runner` linters job, so we are moving this job in repo. See https://github.com/ansible/ansible-runner/pull/859