### PR TITLE
ensure the EC2 nodes have git installed

### DIFF
--- a/playbooks/base-minimal-test/pre.yaml
+++ b/playbooks/base-minimal-test/pre.yaml
@@ -33,6 +33,12 @@
 
 - hosts: all:!appliance*
   tasks:
+    - name: Install git (AWS EC2)
+      package:
+        name: git
+        state: present
+      become: true
+      when: nodepool.provider.startswith("ec2")
     - name: Run prepare-workspace-git role
       include_role:
         name: prepare-workspace-git


### PR DESCRIPTION
Git is supposed to be installed by cloud-init, but the installation
may have failed or just still be running in parallel.
