### PR TITLE
enable the ec2/git workaround

### DIFF
--- a/playbooks/base-minimal-test/pre.yaml
+++ b/playbooks/base-minimal-test/pre.yaml
@@ -40,7 +40,7 @@
       become: true
       # cloud-init may also be running in parallel
       register: result
-      retries: 3
+      retries: 6
       delay: 10
       until: result is not failed
       when: nodepool.provider.startswith("ec2")

--- a/playbooks/base-minimal/pre.yaml
+++ b/playbooks/base-minimal/pre.yaml
@@ -33,6 +33,17 @@
 
 - hosts: all:!appliance*
   tasks:
+    - name: Install git (AWS EC2)
+      package:
+        name: git
+        state: present
+      become: true
+      # cloud-init may also be running in parallel
+      register: result
+      retries: 6
+      delay: 10
+      until: result is not failed
+      when: nodepool.provider.startswith("ec2")
     - name: Run prepare-workspace-git role
       include_role:
         name: prepare-workspace-git


### PR DESCRIPTION
Ensure our ec2 have got git installed before we continue to
prepare-workspace-git.
Git is pulled by cloud-init in the background and this leads
sometime to race condition.
