### PR TITLE
ec2: ensure the zuul-console daemon is running

### DIFF
--- a/playbooks/base-minimal-test/pre.yaml
+++ b/playbooks/base-minimal-test/pre.yaml
@@ -27,16 +27,18 @@
         zuul_ssh_key_algorithm: ecdsa
         zuul_ssh_key_size: 521
 
-    - name: Run start-zuul-console role
-      include_role:
-        name: start-zuul-console
-
 - hosts: controller
   tasks:
     - name: Ensure the EC2 nodes are up to date
       when: nodepool.provider.startswith("ec2")
       include_role:
         name: install-base-packages
+
+- hosts: all:!appliance
+  tasks:
+    - name: Run start-zuul-console role
+      include_role:
+        name: start-zuul-console
 
 - hosts: all:!appliance*
   tasks:


### PR DESCRIPTION
Start start-zuul-console after the ec2 reboot to be sure the service is
running.
