### PR TITLE
ee-tests template for c.vmware and c.aws

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -223,6 +223,8 @@
       - system-required
       - publish-to-galaxy
       - ansible-collections-community-aws
+      - network-ee-container-image-jobs
+      - network-ee-tests
 
 - project:
     name: github.com/ansible-collections/community.azure
@@ -390,6 +392,8 @@
       - system-required
       - ansible-collections-community-vmware
       - integrated-vmware-queue
+      - network-ee-container-image-jobs
+      - network-ee-tests
       - publish-to-galaxy
 
 - project:


### PR DESCRIPTION
Enable network-ee-tests for:

- community.vmware
- community.aws
