### PR TITLE
Revert "ee-tests template for c.vmware and c.aws"

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -223,8 +223,6 @@
       - system-required
       - publish-to-galaxy
       - ansible-collections-community-aws
-      - network-ee-container-image-jobs
-      - network-ee-tests
 
 - project:
     name: github.com/ansible-collections/community.azure
@@ -392,8 +390,6 @@
       - system-required
       - ansible-collections-community-vmware
       - integrated-vmware-queue
-      - network-ee-container-image-jobs
-      - network-ee-tests
       - publish-to-galaxy
 
 - project:


### PR DESCRIPTION
Reverting follow up to a quick discussion with Paul. To do that
properly, we should create a new ee-community template. We should also
add the collections to awx-ee.

This reverts commit de1e156a4096a486b1a19dfa9e5dae1edea65cbd.
