### PR TITLE
Switch runner and builder merge mode to squash-merge

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -874,6 +874,7 @@
 - project:
     name: github.com/ansible/ansible-builder
     default-branch: devel
+    merge-mode: squash-merge
     templates:
       - execution-environments-queue
       - system-required
@@ -897,6 +898,7 @@
 - project:
     name: github.com/ansible/ansible-runner
     default-branch: devel
+    merge-mode: squash-merge
     templates:
       - system-required
       - execution-environments-queue


### PR DESCRIPTION
Tried adding this setting to `ansible-runner` and `ansible-builder` repo project definitions (https://github.com/ansible/ansible-runner/pull/890 and https://github.com/ansible/ansible-builder/pull/296), but doesn't look like its working from there.