### PR TITLE
tox linters with gh cli - update test directory

### DIFF
--- a/playbooks/configure-tox-with-gh-cli/pre.yaml
+++ b/playbooks/configure-tox-with-gh-cli/pre.yaml
@@ -16,7 +16,7 @@
     - name: Copy github token into file
       copy:
         content: "{{ ansible_github_token.value }}"
-        dest: "{{ zuul.project.src_dir }}/github_token_file.txt"
+        dest: "{{ zuul_work_dir }}/github_token_file.txt"
 
   roles:
     - ensure-python


### PR DESCRIPTION
zuul_work_dir used to deliver github token