### PR TITLE
tox linters with gh cli

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -968,9 +968,11 @@
     check:
       jobs:
         - project-config-tox-github
+        - project-config-tox-linters
     gate:
       jobs:
         - project-config-tox-github
+        - project-config-tox-linters
     periodic:
       jobs:
         - refresh-automation-hub-token


### PR DESCRIPTION
Ensure tox linters validate projects default branch using ``gh`` cli