### PR TITLE
turn project-config-tox-linters non-voting

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -100,6 +100,7 @@
     pre-run: playbooks/configure-tox-with-gh-cli/pre.yaml
     secrets:
       - ansible_github_token
+    voting: false
 
 - job:
     name: propose-github-updates


### PR DESCRIPTION
Turn project-config-tox-linters non-voting until we've got it stabilize
and we've generated the final token.
