### PR TITLE
revert non-voting job setting

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -100,7 +100,6 @@
     pre-run: playbooks/configure-tox-with-gh-cli/pre.yaml
     secrets:
       - ansible_github_token
-    voting: false
 
 - job:
     name: propose-github-updates


### PR DESCRIPTION
project-config linters job was temporary set as non voting before getting the permanent github token.
As this is integrate now via #980 this one can be merged after