### PR TITLE
Remove ansible-test-network-integration template from ansible/ansible

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -838,8 +838,6 @@
 - project:
     name: github.com/ansible/ansible
     default-branch: devel
-    templates:
-      - ansible-test-network-integration
     third-party-check-silent:
       jobs:
         - ansible-runner-build-container-image-stable-2.9:


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

As we have removed all the network periodic jobs from ansible/ansible, the template ansible-test-network-integration is no longer needed.