### PR TITLE
Switch a few more jobs to centos-8-stream

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -81,7 +81,7 @@
       tox env.
     vars:
       tox_envlist: github
-    nodeset: centos-8-1vcpu
+    nodeset: centos-8-stream
     files:
       - github/projects.yaml
       - requirements.txt
@@ -108,7 +108,7 @@
     post-run: playbooks/propose-github-updates/post.yaml
     secrets:
       - github_proposal_bot
-    nodeset: centos-8-1vcpu
+    nodeset: centos-8-stream
 
 - job:
     name: build-ansible-collection


### PR DESCRIPTION
We want to stop using centos-8-1vcpu nodeset, given it runs
on older flavors (which are slower then centos-8-stream).

Signed-off-by: Paul Belanger <pabelanger@redhat.com>