### PR TITLE
ansible-zuul-jobs: load config from zuul.ansible.d/ too

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -16,7 +16,9 @@
           - ansible/project-config
         untrusted-projects:
           # Order matters, load common job repos first
-          - ansible/ansible-zuul-jobs
+          - ansible/ansible-zuul-jobs:
+              extra-config-paths: [zuul.ansible.d/*]
+
           # After this point, sorting projects alphabetically will help
           # merge conflicts
           - ansible/ansible-builder


### PR DESCRIPTION
The nodepool configuration is specific to zuul.ansible.com. We will move
it in this directory. This way, we can reuse the rest of the repository
with SF.
