### PR TITLE
extra-config-paths: Directories should be listed with a trailing /

### DIFF
--- a/zuul/tenants.yaml
+++ b/zuul/tenants.yaml
@@ -17,7 +17,7 @@
         untrusted-projects:
           # Order matters, load common job repos first
           - ansible/ansible-zuul-jobs:
-              extra-config-paths: [zuul.ansible.d/*]
+              extra-config-paths: [zuul.ansible.d/]
 
           # After this point, sorting projects alphabetically will help
           # merge conflicts


### PR DESCRIPTION
See: https://zuul-ci.org/docs/zuul/reference/tenants.html
