### PR TITLE
vmware.vmware_rest is a dep of network-ee-container-image-jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -558,6 +558,10 @@
       - publish-to-automation-hub
 
 - project:
+    name: github.com/ansible-collections/vmware.vmware_rest
+    default-branch: main
+
+- project:
     name: github.com/ansible-collections/vyos.vyos
     default-branch: main
     merge-mode: squash-merge


### PR DESCRIPTION
Ensure the vmware.vmware_rest is still defined and that we set
the right default branch.

This to avoid the following error:

x build-ansible-collection ERROR Project github.com/ansible-collections/vmware.vmware_rest does not have the default branch master in 19s
