### PR TITLE
Revert "Remove ansible-runner project"

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -869,6 +869,35 @@
       - publish-to-pypi
 
 - project:
+    name: github.com/ansible/ansible-runner
+    default-branch: devel
+    merge-mode: squash-merge
+    templates:
+      - system-required
+      - execution-environments-queue
+      - publish-to-pypi
+    check:
+      jobs:
+        - ansible-runner-tox-ansible29:
+            branches: 'devel'
+        - ansible-runner-tox-ansible-base:  # not expecting older stable versions to support ansible-base
+            branches: 'devel'
+        - ansible-tox-py27:
+            branches: '^stable/1.*'
+        - ansible-tox-py36:
+            branches: '^stable/1.*'
+    gate:
+      jobs:
+        - ansible-runner-tox-ansible29:
+            branches: 'devel'
+        - ansible-runner-tox-ansible-base:  # not expecting older stable versions to support ansible-base
+            branches: 'devel'
+        - ansible-tox-py27:
+            branches: '^stable/1.*'
+        - ansible-tox-py36:
+            branches: '^stable/1.*'
+
+- project:
     name: github.com/ansible/ansible-zuul-jobs
     merge-mode: squash-merge
     templates:


### PR DESCRIPTION
Reverts ansible/project-config#1003

ansible-runner project is needed for the network platform jobs. So reverting this change.