### PR TITLE
network-engine is on SF now

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -658,15 +658,7 @@
     name: github.com/ansible-network/network-engine
     default-branch: devel
     templates:
-      - ansible-python3-jobs
-    check:
-      jobs:
-        - ansible-tox-linters
-        - ansible-tox-py27
-    gate:
-      jobs:
-        - ansible-tox-linters
-        - ansible-tox-py27
+      - noop-jobs
 
 - project:
     name: github.com/ansible-network/network-image-builder


### PR DESCRIPTION
See: https://github.com/ansible/zuul-config/pull/280
