### PR TITLE
frr.frr is on SF now

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -384,14 +384,7 @@
     default-branch: main
     merge-mode: squash-merge
     templates:
-      - system-required
-      - ansible-collections-frr-frr-units
-      - ansible-python-jobs
-      - integrated-queue
-      - network-ee-container-image-jobs
-      - network-ee-tests
-      - publish-to-galaxy
-      - publish-to-automation-hub
+      - noop-jobs
 
 - project:
     name: github.com/ansible-collections/hetzner.hcloud


### PR DESCRIPTION
See: https://github.com/ansible/zuul-config/pull/282
