### PR TITLE
qradar: remove network-ee related jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -320,8 +320,6 @@
       - ansible-collections-security-ibm-qradar
       - ansible-python-jobs
       - integrated-queue
-      - network-ee-container-image-jobs
-      - network-ee-tests
 
 - project:
     name: github.com/ansible-collections/junipernetworks.junos


### PR DESCRIPTION
These will be replaced by the ansible-ee jobs.

See: https://github.com/ansible/ansible-zuul-jobs/pull/1395
