### PR TITLE
cisco.iosxr is fully migrated

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -109,13 +109,7 @@
     default-branch: main
     merge-mode: squash-merge
     templates:
-      - system-required
-      - ansible-collections-cisco-iosxr
-      - ansible-collections-cisco-iosxr-units
-      - ansible-python-jobs
-      - network-ee-container-image-jobs
-      - network-ee-tests
-      - integrated-queue
+      - noop-jobs
 
 - project:
     name: github.com/ansible-collections/cisco.nxos


### PR DESCRIPTION
See: https://github.com/ansible/zuul-config/pull/346
